### PR TITLE
Implement language detection, label service macro for SPARQL

### DIFF
--- a/scholia/app/templates/sparql-helpers.sparql
+++ b/scholia/app/templates/sparql-helpers.sparql
@@ -1,0 +1,33 @@
+{% macro labels(variables, languages) -%}
+  {% for variable in variables -%}
+    {% for language in languages -%}
+      OPTIONAL { {{ variable }} <http://www.w3.org/2000/01/rdf-schema#label> {{ variable }}Label_{{ language | replace("-", "_") }}. FILTER(LANG({{ variable }}Label_{{ language | replace("-", "_") }}) = "{{ language }}") }
+    {% endfor -%}
+    BIND(COALESCE(
+    {%- for language in languages -%}
+      {{ variable }}Label_{{ language | replace("-", "_") }}
+      {%- if not loop.last %}, {% endif %}
+    {%- endfor -%}
+    ) AS {{ variable }}Label)
+
+    {%- if not loop.last %}
+    {% endif %}
+  {%- endfor %}
+{%- endmacro -%}
+
+{%- macro descriptions(variables, languages) -%}
+  {% for variable in variables -%}
+    {% for language in languages -%}
+      OPTIONAL { {{ variable }} <http://schema.org/description> {{ variable }}Description_{{ language | replace("-", "_") }}. FILTER(LANG({{ variable }}Description_{{ language | replace("-", "_") }}) = "{{ language }}") }
+    {% endfor -%}
+    BIND(COALESCE(
+    {%- for language in languages -%}
+      {{ variable }}Description_{{ language | replace("-", "_") }}
+      {%- if not loop.last %}, {% endif %}
+    {%- endfor -%}
+    ) AS {{ variable }}Description)
+
+    {%- if not loop.last %}
+    {% endif %}
+  {%- endfor %}
+{%- endmacro -%}

--- a/scholia/app/templates/taxon_co-occurring-taxa.sparql
+++ b/scholia/app/templates/taxon_co-occurring-taxa.sparql
@@ -3,7 +3,6 @@
 #title: Taxa that co-occur with the target taxon in the literature
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?count (CONCAT("/topics/", SUBSTR(STR(target:),32), ",", SUBSTR(STR(?taxon),32)) AS ?countUrl) ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon),32)) AS ?taxonUrl) ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work),32)) AS ?example_workUrl) WHERE {

--- a/scholia/app/templates/taxon_co-occurring-taxa.sparql
+++ b/scholia/app/templates/taxon_co-occurring-taxa.sparql
@@ -1,6 +1,9 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #title: Taxa that co-occur with the target taxon in the literature
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?count (CONCAT("/topics/", SUBSTR(STR(target:),32), ",", SUBSTR(STR(?taxon),32)) AS ?countUrl) ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon),32)) AS ?taxonUrl) ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work),32)) AS ?example_workUrl) WHERE {
@@ -18,7 +21,7 @@ SELECT ?count (CONCAT("/topics/", SUBSTR(STR(target:),32), ",", SUBSTR(STR(?taxo
     }
     GROUP BY ?taxon
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
+  {{ sparql_helpers.labels(["?taxon", "?example_work"], languages) }}
 }
 ORDER BY DESC(?count)
 LIMIT 200

--- a/scholia/app/templates/taxon_genome.sparql
+++ b/scholia/app/templates/taxon_genome.sparql
@@ -1,15 +1,14 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?gene ?geneLabel ?geneDescription ?chromosome ?chromosomeLabel ?chromosomeDescription {
-  {
-    SELECT ?gene ?chromosome WHERE {
-      ?gene wdt:P31 wd:Q7187 ;
-            wdt:P703 target: ;
-            wdt:P1057 ?chromosome .
-    }
-  }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+  ?gene wdt:P31 wd:Q7187 ;
+        wdt:P703 target: ;
+        wdt:P1057 ?chromosome .
+  {{ sparql_helpers.labels(["?gene", "?chromosome"], languages) }}
+  {{ sparql_helpers.descriptions(["?gene", "?chromosome"], languages) }}
 }

--- a/scholia/app/templates/taxon_identifiers.sparql
+++ b/scholia/app/templates/taxon_identifiers.sparql
@@ -1,3 +1,5 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wd: <http://www.wikidata.org/entity/>
@@ -44,7 +46,8 @@ SELECT ?Identifier ?IdentifierLabel ?id (SAMPLE(?idUrls) AS ?idUrl) ?IdentifierD
       BIND (IRI(REPLACE(?formatterurl, '\\\\$1', STR(?id))) AS ?idUrls) .
     }
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+  {{ sparql_helpers.labels(["?Identifier"], languages) }}
+  {{ sparql_helpers.descriptions(["?Identifier"], languages) }}
 }
 GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?id
 ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/taxon_metabolome.sparql
+++ b/scholia/app/templates/taxon_metabolome.sparql
@@ -1,3 +1,5 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wd: <http://www.wikidata.org/entity/>
@@ -25,5 +27,6 @@ SELECT DISTINCT ?metabolite ?metaboliteLabel ?metaboliteChemicalStructure ?metab
       BIND (COALESCE(?isoSmiles, ?canSmiles) AS ?metaboliteChemicalStructure)
     }
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+  {{ sparql_helpers.labels(["?metabolite"], languages) }}
+  {{ sparql_helpers.descriptions(["?metabolite"], languages) }}
 }

--- a/scholia/app/templates/taxon_parent-taxa.sparql
+++ b/scholia/app/templates/taxon_parent-taxa.sparql
@@ -5,11 +5,11 @@ PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT (COUNT(?middle) AS ?distance) (GROUP_CONCAT(DISTINCT ?rank_Label; SEPARATOR=", ") AS ?rank) ?parent ?parentLabel ?parentDescription {
+SELECT (COUNT(?middle) AS ?distance) (GROUP_CONCAT(DISTINCT ?_rankLabel; SEPARATOR=", ") AS ?rank) ?parent ?parentLabel ?parentDescription {
   target: wdt:P171* ?middle .
   ?middle wdt:P171+ ?parent .
-  ?parent wdt:P105 ?rank_ .
-  {{ sparql_helpers.labels(["?rank_", "?parent"], languages) }}
+  ?parent wdt:P105 ?_rank .
+  {{ sparql_helpers.labels(["?_rank", "?parent"], languages) }}
   {{ sparql_helpers.descriptions(["?parent"], languages) }}
 }
 GROUP BY ?parent ?parentLabel ?parentDescription

--- a/scholia/app/templates/taxon_parent-taxa.sparql
+++ b/scholia/app/templates/taxon_parent-taxa.sparql
@@ -1,16 +1,16 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT (COUNT(?middle) AS ?distance) (GROUP_CONCAT(DISTINCT ?rank_label_; SEPARATOR=", ") AS ?rank) ?parent ?parentLabel ?parentDescription {
+SELECT (COUNT(?middle) AS ?distance) (GROUP_CONCAT(DISTINCT ?rank_Label; SEPARATOR=", ") AS ?rank) ?parent ?parentLabel ?parentDescription {
   target: wdt:P171* ?middle .
   ?middle wdt:P171+ ?parent .
   ?parent wdt:P105 ?rank_ .
-  OPTIONAL {
-    ?rank_ rdfs:label ?rank_label_ . FILTER (LANG(?rank_label_) = 'en')
-  }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+  {{ sparql_helpers.labels(["?rank_", "?parent"], languages) }}
+  {{ sparql_helpers.descriptions(["?parent"], languages) }}
 }
 GROUP BY ?parent ?parentLabel ?parentDescription
 ORDER BY ?distance

--- a/scholia/app/templates/taxon_proteome.sparql
+++ b/scholia/app/templates/taxon_proteome.sparql
@@ -1,15 +1,14 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?protein ?proteinLabel ?proteinDescription ?gene ?geneLabel {
-  {
-    SELECT ?protein ?gene ?chromosome WHERE {
-      ?protein wdt:P31 wd:Q8054 ;
-               wdt:P703 target: .
-    }
-  }
-  ?protein wdt:P702 ?gene .
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+  ?protein wdt:P31 wd:Q8054 ;
+           wdt:P703 target: ;
+           wdt:P702 ?gene.
+  {{ sparql_helpers.labels(["?protein", "?gene"], languages) }}
+  {{ sparql_helpers.descriptions(["?protein"], languages) }}
 }

--- a/scholia/app/templates/taxon_tree.sparql
+++ b/scholia/app/templates/taxon_tree.sparql
@@ -1,47 +1,38 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Graph
-PREFIX target: <http://www.wikidata.org/entity/{{q}}>
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-SELECT ?child ?childLabel ?rgb ?parent ?parentLabel WHERE {
+SELECT (?child_ AS ?child) ?childLabel ?rgb (?parent_ AS ?parent) ?parentLabel WHERE {
   {
-    SELECT ?child ?rgb ?parent WHERE {
-      {
-        # Parent taxa
-        SELECT ?child ?rgb ?parent WHERE {
-          {
-            SELECT ?parent ?child  WHERE {
-              # Forward traversal: all parent taxa and their direct child taxon 
-              # compute all reachable parent taxa
-              target: wdt:P171+ ?parent .
-              # compute all of their direct children
-              ?child wdt:P171 ?parent .
-              # ensure that the child taxon is a predecessor of the target taxon
-              target: wdt:P171* ?child .
-            } GROUP BY ?parent ?child
-          }
-          BIND (IF(?child = target:,"FF0000","FFFFFF") AS ?rgb)
-        }
-      }
-      UNION {
-        # Child taxa
-        SELECT ?child ?rgb ?parent WHERE {
-          BIND (target: AS ?parent)
-          ?child wdt:P171 ?parent .
-          BIND ("DDDDDD" AS ?rgb)
-        }
-        LIMIT 100
-      }
-    }
+    # Parent taxa
+    target: wdt:P171* ?child_ .
+    ?child_ wdt:P171 ?parent_ .
+    BIND ("FFFFFF" AS ?rgb)
+  } UNION {
+    # Child taxa
+    {SELECT ?child_ ?parent_ WHERE {
+      BIND (target: AS ?parent_) .
+      ?child_ wdt:P171 ?parent_ .
+    } LIMIT 100}
+    BIND ("DDDDDD" AS ?rgb)
+  } UNION {
+    BIND (target: AS ?child_) .
+    ?child_ wdt:P171 ?parent_ .
+    BIND ("FF0000" AS ?rgb)
   }
-  ### This labeling code creates duplicate nodes with differing labels through the usage of the OPTIONAL keyword ###
-  # ?child rdfs:label ?child_label . FILTER (LANG(?child_label) = 'en')
-  # ?parent rdfs:label ?parent_label . FILTER (LANG(?parent_label) = 'en')
-  # OPTIONAL {
-  #   ?child wdt:P105/rdfs:label ?child_rank_label . FILTER (LANG(?child_rank_label) = 'en')
-  # }
-  # OPTIONAL {
-  #   ?parent wdt:P105/rdfs:label ?parent_rank_label . FILTER (LANG(?parent_rank_label) = 'en')
-  # }
-  # BIND (CONCAT(?child_label, " - ", COALESCE(?child_rank_label, "???")) AS ?childLabel)
-  # BIND (CONCAT(?parent_label, " - ", COALESCE(?parent_rank_label, "???")) AS ?parentLabel)
+
+  OPTIONAL {
+    ?child_ wdt:P105 ?child_rank_ .
+    {{ sparql_helpers.labels(["?child_rank_"], languages) }}
+  }
+  OPTIONAL {
+    ?parent_ wdt:P105 ?parent_rank_ .
+    {{ sparql_helpers.labels(["?parent_rank_"], languages) }}
+  }
+  {{ sparql_helpers.labels(["?child_", "?parent_"], languages) }}
+
+  BIND (CONCAT(?child_Label, " - ", COALESCE(?child_rank_Label, "???")) AS ?childLabel)
+  BIND (CONCAT(?parent_Label, " - ", COALESCE(?parent_rank_Label, "???")) AS ?parentLabel)
 }

--- a/scholia/app/templates/taxon_tree.sparql
+++ b/scholia/app/templates/taxon_tree.sparql
@@ -4,35 +4,35 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-SELECT (?child_ AS ?child) ?childLabel ?rgb (?parent_ AS ?parent) ?parentLabel WHERE {
+SELECT (?_child AS ?child) ?childLabel ?rgb (?_parent AS ?parent) ?parentLabel WHERE {
   {
     # Parent taxa
-    target: wdt:P171* ?child_ .
-    ?child_ wdt:P171 ?parent_ .
+    target: wdt:P171* ?_child .
+    ?_child wdt:P171 ?_parent .
     BIND ("FFFFFF" AS ?rgb)
   } UNION {
     # Child taxa
-    {SELECT ?child_ ?parent_ WHERE {
-      BIND (target: AS ?parent_) .
-      ?child_ wdt:P171 ?parent_ .
+    {SELECT ?_child ?_parent WHERE {
+      BIND (target: AS ?_parent) .
+      ?_child wdt:P171 ?_parent .
     } LIMIT 100}
     BIND ("DDDDDD" AS ?rgb)
   } UNION {
-    BIND (target: AS ?child_) .
-    ?child_ wdt:P171 ?parent_ .
+    BIND (target: AS ?_child) .
+    ?_child wdt:P171 ?_parent .
     BIND ("FF0000" AS ?rgb)
   }
 
   OPTIONAL {
-    ?child_ wdt:P105 ?child_rank_ .
-    {{ sparql_helpers.labels(["?child_rank_"], languages) }}
+    ?_child wdt:P105 ?_childRank .
+    {{ sparql_helpers.labels(["?_childRank"], languages) }}
   }
   OPTIONAL {
-    ?parent_ wdt:P105 ?parent_rank_ .
-    {{ sparql_helpers.labels(["?parent_rank_"], languages) }}
+    ?_parent wdt:P105 ?_parentRank .
+    {{ sparql_helpers.labels(["?_parentRank"], languages) }}
   }
-  {{ sparql_helpers.labels(["?child_", "?parent_"], languages) }}
+  {{ sparql_helpers.labels(["?_child", "?_parent"], languages) }}
 
-  BIND (CONCAT(?child_Label, " - ", COALESCE(?child_rank_Label, "???")) AS ?childLabel)
-  BIND (CONCAT(?parent_Label, " - ", COALESCE(?parent_rank_Label, "???")) AS ?parentLabel)
+  BIND (CONCAT(?_childLabel, " - ", COALESCE(?_childRankLabel, "???")) AS ?childLabel)
+  BIND (CONCAT(?_parentLabel, " - ", COALESCE(?_parentRankLabel, "???")) AS ?parentLabel)
 }

--- a/scholia/app/templates/taxon_tree.sparql
+++ b/scholia/app/templates/taxon_tree.sparql
@@ -2,12 +2,11 @@
 
 #defaultView:Graph
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 SELECT (?_child AS ?child) ?childLabel ?rgb (?_parent AS ?parent) ?parentLabel WHERE {
   {
     # Parent taxa
-    target: wdt:P171* ?_child .
+    target: wdt:P171+ ?_child .
     ?_child wdt:P171 ?_parent .
     BIND ("FFFFFF" AS ?rgb)
   } UNION {

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -3,7 +3,8 @@
 import datetime
 import re
 
-from flask import (Blueprint, current_app, redirect, render_template as render_template_base,
+from flask import (Blueprint, current_app, redirect,
+                   render_template as render_template_base,
                    request, Response, url_for)
 from jinja2 import TemplateNotFound
 from werkzeug.routing import BaseConverter
@@ -384,12 +385,13 @@ def get_js_config():
         config['query-server'].get('sparql_endpoint_name'),
     }
 
+
 def get_languages():
     """Get language fallback chain for a given request.
 
     Returns
     -------
-    languages : str[]
+    languages : list[str]
         Language fallback chain.
 
     """
@@ -399,10 +401,27 @@ def get_languages():
     languages.append('mul')
     return languages
 
-def render_template(*args, **kwargs):
-    if 'languages' not in kwargs:
-        kwargs['languages'] = get_languages()
-    return render_template_base(*args, **kwargs)
+
+def render_template(template_name_or_list, **context):
+    """Render a template by name with the given context.
+
+    Wrapper around flask.render_template, which automatically
+    determines language fallback chain from request headers.
+
+    Parameters
+    ----------
+    template_name_or_list : str or list[str]
+        The name of the template to render. If a list is given,
+        the first name to exist will be rendered.
+
+    context : dict
+        The variables to make available in the template.
+
+    """
+    if 'languages' not in context:
+        context['languages'] = get_languages()
+    return render_template_base(template_name_or_list, **context)
+
 
 @main.context_processor
 def inject_js_config():

--- a/scholia/app/views.py
+++ b/scholia/app/views.py
@@ -3,8 +3,8 @@
 import datetime
 import re
 
-from flask import (Blueprint, current_app, redirect, render_template, request,
-                   Response, url_for)
+from flask import (Blueprint, current_app, redirect, render_template as render_template_base,
+                   request, Response, url_for)
 from jinja2 import TemplateNotFound
 from werkzeug.routing import BaseConverter
 
@@ -384,6 +384,25 @@ def get_js_config():
         config['query-server'].get('sparql_endpoint_name'),
     }
 
+def get_languages():
+    """Get language fallback chain for a given request.
+
+    Returns
+    -------
+    languages : str[]
+        Language fallback chain.
+
+    """
+    languages = [x[0] for x in request.accept_languages]
+    if 'en' not in request.accept_languages:
+        languages.append('en')
+    languages.append('mul')
+    return languages
+
+def render_template(*args, **kwargs):
+    if 'languages' not in kwargs:
+        kwargs['languages'] = get_languages()
+    return render_template_base(*args, **kwargs)
 
 @main.context_processor
 def inject_js_config():


### PR DESCRIPTION
Fixes #17

### Description
- Wraps `flask.render_table` to automatically get the `Accept-Language` header and process it into a language fallback chain (in this case: user languages, `en` if not already selected, `mul`) and pass it as `languages` to all templates.
- Adds macros in `sparql-helpers.sparql`: `sparql_helpers.labels(variables, languages)` and `sparql_helpers.descriptions(variables, languages)`
- Updates all queries in the `taxon` aspect to use these macros as examples
  
### Caveats

* [ ]  My code passes the [tox](https://tox.readthedocs.io/en/latest/) check, I can receive warnings about tests, documentation or both

### Testing
* Go to http://127.0.0.1:8100/taxon/Q15978631, check that all queries work
* Also check with a non-English browser, to check if language detection works, and if fallback works

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [ ] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
