### PR TITLE
Labels for a few /author/ panels

### DIFF
--- a/scholia/app/templates/author_list-of-publications.sparql
+++ b/scholia/app/templates/author_list-of-publications.sparql
@@ -1,3 +1,4 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
@@ -37,7 +38,7 @@ SELECT (MIN(?dates) AS ?date) ?work ?workLabel (GROUP_CONCAT(DISTINCT ?type_labe
   OPTIONAL {
     ?work wdt:P1433 ?venue
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }  
+  {{ sparql_helpers.labels(["?work", "?venue"], languages) }}
 }
 GROUP BY ?work ?workLabel ?venue ?venueLabel
 ORDER BY DESC(?date)

--- a/scholia/app/templates/author_list-of-retracted-articles.sparql
+++ b/scholia/app/templates/author_list-of-retracted-articles.sparql
@@ -1,3 +1,4 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
@@ -34,7 +35,7 @@ SELECT (MIN(?dates) AS ?date) ?work ?workLabel (CONCAT("../retraction/", SUBSTR(
   OPTIONAL {
     ?work wdt:P1433 ?venue
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+  {{ sparql_helpers.labels(["?work", "?venue"], languages) }}
 }
 GROUP BY ?work ?workLabel ?workUrl ?venue ?venueLabel
 ORDER BY DESC(?date)

--- a/scholia/app/templates/author_topics.sparql
+++ b/scholia/app/templates/author_topics.sparql
@@ -1,9 +1,10 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?count ?theme (REPLACE(STR(?theme), ".*/", "") AS ?themeLabel) ?example_work (REPLACE(STR(?example_work), ".*/", "") AS ?example_workLabel) WHERE {
+SELECT ?count ?theme ?themeLabel ?example_work ?example_workLabel WHERE {
   {
     SELECT (COUNT(?work) AS ?count) ?theme (SAMPLE(?work) AS ?example_work) WHERE {
       ?work wdt:P50 target: .
@@ -11,6 +12,6 @@ SELECT ?count ?theme (REPLACE(STR(?theme), ".*/", "") AS ?themeLabel) ?example_w
     }
     GROUP BY ?theme
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
+  {{ sparql_helpers.labels(["?theme", "?example_work"], languages) }}
 }
 ORDER BY DESC(?count)


### PR DESCRIPTION
Patch on top of `qlever` to add labels to a few `/author/` panels.

For example, the topics panel now shows English labels (for me) instead of QIDs:

<img width="1157" height="777" alt="image" src="https://github.com/user-attachments/assets/f3892dfe-8d35-4d0b-a443-98a9e47f8fd4" />
