### PR TITLE
Update queries of retraction and topic

### DIFF
--- a/scholia/app/templates/retraction_citations-per-year.sparql
+++ b/scholia/app/templates/retraction_citations-per-year.sparql
@@ -6,36 +6,16 @@ PREFIX ps: <http://www.wikidata.org/prop/statement/>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-SELECT (STR(?year_) AS ?year) (SUM(?count_) AS ?count) ?kind WHERE {
-  {
-    SELECT ?year_ (COUNT(DISTINCT ?citing_work) AS ?count_) ?kind2 WHERE {
-      ?citing_work wdt:P2860 target: .
-      # Year of citation
-      ?citing_work wdt:P577 ?date .
-      BIND (YEAR(?date) AS ?year_)
-      BIND (xsd:date(?date) AS ?pubDate_)
-      target: p:P31 ?isRetractedPaperStatement .
-      ?isRetractedPaperStatement ps:P31 wd:Q45182324 .
-      ?isRetractedPaperStatement pq:P580 ?retractionDate
-      BIND (xsd:date(?retractionDate) AS ?retractionDate_)
-      BIND (IF(?retractionDate_ > ?pubDate_,"before retraction","after retraction") AS ?kind2)
-    }
-    GROUP BY ?year_ ?kind2
-  }
-  UNION {
-    SELECT ?year_ (COUNT(DISTINCT ?citing_work) AS ?count_) ?kind2 WHERE {
-      ?citing_work wdt:P2860 target: .
-      # Year of citation
-      ?citing_work wdt:P577 ?date .
-      BIND (YEAR(?date) AS ?year_)
-      BIND (xsd:date(?date) AS ?pubDate_)
-      MINUS {
-        target: p:P31/pq:P580 ?retractionDate
-      }
-    }
-    GROUP BY ?year_ ?kind2
-  }
-  BIND (IF(BOUND(?kind2),?kind2,"_") AS ?kind)
-}
-GROUP BY ?year_ ?kind
-ORDER BY DESC(?year_)
+SELECT (STR(?_year) AS ?year) (COUNT(DISTINCT ?citing_work) AS ?count) ?kind WHERE {
+  ?citing_work wdt:P2860 target: ;
+               wdt:P577 ?date .
+  OPTIONAL { target: p:P31 [ ps:P31 wd:Q45182324 ; pq:P580 ?retractionDate ] }
+  # Year of citation
+  BIND (YEAR(?date) AS ?_year)
+  # Type of citation
+  BIND (IF(BOUND(?retractionDate),
+    IF(xsd:date(?retractionDate) > xsd:date(?date), "before retraction", "after retraction"),
+    "_"
+  ) AS ?kind)
+} GROUP BY ?_year ?kind
+  ORDER BY DESC(?_year)

--- a/scholia/app/templates/retraction_data.sparql
+++ b/scholia/app/templates/retraction_data.sparql
@@ -1,3 +1,5 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
@@ -8,97 +10,88 @@ PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
 SELECT DISTINCT ?description ?value ?valueUrl WHERE {
-  BIND (target: AS ?work)
   {
     BIND (1 AS ?order)
     BIND ("Title" AS ?description)
-    ?work wdt:P1476 ?value .
+    target: wdt:P1476 ?value .
   }
   UNION {
-    SELECT (2 AS ?order) ("Reviewers" AS ?description) (GROUP_CONCAT(?value_; SEPARATOR=", ") AS ?value) (CONCAT("../authors/", GROUP_CONCAT(?q; SEPARATOR=",")) AS ?valueUrl) {
-      BIND (1 AS ?dummy)
-      target: wdt:P4032 ?iri .
-      BIND (SUBSTR(STR(?iri),32) AS ?q)
-      ?iri rdfs:label ?value_string .
-      FILTER (LANG(?value_string) = 'en')
-      BIND (COALESCE(?value_string, ?q) AS ?value_)
-    }
-    GROUP BY ?dummy
+    BIND (2 AS ?order)
+    BIND ("Reviewers" AS ?description)
+    {SELECT (GROUP_CONCAT(?value_; SEPARATOR=", ") AS ?value) (CONCAT("../authors/", GROUP_CONCAT(?q; SEPARATOR=",")) AS ?valueUrl) {
+      target: wdt:P4032 ?reviewer .
+      {{ sparql_helpers.labels(["?reviewer"], languages) }}
+      BIND (SUBSTR(STR(?reviewer), 32) AS ?q)
+      BIND (COALESCE(?reviewerLabel, ?q) AS ?value_)
+    }}
   }
   UNION {
     BIND (3 AS ?order)
     BIND ("Published in" AS ?description)
-    ?work wdt:P1433 ?iri .
-    BIND (SUBSTR(STR(?iri),32) AS ?q)
-    ?iri rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (COALESCE(?value_string, ?q) AS ?value)
+    target: wdt:P1433 ?venue .
+    {{ sparql_helpers.labels(["?venue"], languages) }}
+    BIND (SUBSTR(STR(?venue), 32) AS ?q)
+    BIND (COALESCE(?venueLabel, ?q) AS ?value)
     BIND (CONCAT("../venue/", ?q) AS ?valueUrl)
   }
   UNION {
     BIND (4 AS ?order)
     BIND ("Publication date" AS ?description)
-    ?work p:P577/psv:P577 ?publication_date_value .
-    ?publication_date_value wikibase:timePrecision ?time_precision ;
-                            wikibase:timeValue ?publication_date .
-    BIND (IF(?time_precision = 9,YEAR(?publication_date),xsd:date(?publication_date)) AS ?value)
+    target: p:P577/psv:P577 [
+      wikibase:timePrecision ?time_precision ;
+      wikibase:timeValue ?publication_date
+    ] .
+    BIND (IF(?time_precision = 9, YEAR(?publication_date), xsd:date(?publication_date)) AS ?value)
   }
   UNION {
     BIND (5 AS ?order)
     BIND ("Retraction date" AS ?description)
-    ?work p:P31 ?isRetractedPaperStatement .
-    ?isRetractedPaperStatement ps:P31 wd:Q45182324 .
-    ?isRetractedPaperStatement pq:P580 ?retraction_date_value .
+    target: p:P31 [ ps:P31 wd:Q45182324 ; pq:P580 ?retraction_date_value ] .
     BIND (xsd:date(?retraction_date_value) AS ?value)
   }
   UNION {
     BIND (6 AS ?order)
     BIND ("Publisher" AS ?description)
-    ?work wdt:P123 ?iri .
-    BIND (SUBSTR(STR(?iri),32) AS ?q)
-    ?iri rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (COALESCE(?value_string, ?q) AS ?value)
+    target: wdt:P123 ?publisher .
+    {{ sparql_helpers.labels(["?publisher"], languages) }}
+    BIND (SUBSTR(STR(?publisher), 32) AS ?q)
+    BIND (COALESCE(?publisherLabel, ?q) AS ?value)
     BIND (CONCAT("../publisher/", ?q) AS ?valueUrl)
   }
   UNION {
     BIND (7 AS ?order)
     BIND ("DOI" AS ?description)
-    ?work wdt:P356 ?valueUrl_ .
-    BIND (CONCAT("https://doi.org/", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
-    BIND (CONCAT(?valueUrl_, " ↗") AS ?value)
+    target: wdt:P356 ?doi .
+    BIND (CONCAT("https://doi.org/", ENCODE_FOR_URI(?doi)) AS ?valueUrl)
+    BIND (CONCAT(?doi, " ↗") AS ?value)
   }
   UNION {
     BIND (8 AS ?order)
     BIND ("🛑 Retracted by" AS ?description)
-    ?work wdt:P5824 ?iri .
-    BIND (SUBSTR(STR(?iri),32) AS ?q)
-    ?iri rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (COALESCE(?value_string, ?q) AS ?value)
+    target: wdt:P5824 ?retraction .
+    {{ sparql_helpers.labels(["?retraction"], languages) }}
+    BIND (SUBSTR(STR(?retraction), 32) AS ?q)
+    BIND (COALESCE(?retractionLabel, ?q) AS ?value)
     BIND (CONCAT("../work/", ?q) AS ?valueUrl)
   }
   UNION {
     BIND (9 AS ?order)
     BIND ("⚠️ Cites retracted article" AS ?description)
     {
-      ?work wdt:P2860 ?retracted .
+      target: wdt:P2860 ?retracted .
       ?retracted wdt:P31 wd:Q45182324 .
-    }
-    UNION {
-      ?work wdt:P2860 ?retracted .
+    } UNION {
+      target: wdt:P2860 ?retracted .
       ?retracted wdt:P793 wd:Q7316896 .
-    }
-    UNION {
-      ?work wdt:P2860 ?retracted .
+    } UNION {
+      target: wdt:P2860 ?retracted .
       ?retracted wdt:P5824 [] .
     }
-    ?retracted rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (SUBSTR(STR(?retracted),32) AS ?q)
-    BIND (COALESCE(?value_string, ?q) AS ?value)
+    {{ sparql_helpers.labels(["?retracted"], languages) }}
+    BIND (SUBSTR(STR(?retracted), 32) AS ?q)
+    BIND (COALESCE(?retractedLabel, ?q) AS ?value)
     BIND (CONCAT("../work/", ?q) AS ?valueUrl)
   }
-}
-ORDER BY ?order
+} ORDER BY ?order

--- a/scholia/app/templates/retraction_list-of-authors.sparql
+++ b/scholia/app/templates/retraction_list-of-authors.sparql
@@ -1,3 +1,5 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 # List of authors for a work
 PREFIX p: <http://www.wikidata.org/prop/>
@@ -7,37 +9,25 @@ PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-SELECT DISTINCT
-# Author order
-?order
-# Author item and label
-?author ?authorUrl (COUNT(DISTINCT ?work) AS ?retractions) WHERE {
+SELECT ?order ?author ?authorLabel ?authorUrl ?retractions WHERE {
   {
-    target: p:P50 ?author_statement .
-    ?author_statement ps:P50 ?author_ .
-    BIND (CONCAT("../author/", SUBSTR(STR(?author_),32), "#list-of-retracted-articles") AS ?authorUrl)
-    OPTIONAL {
-      ?author_statement pq:P1545 ?order_ .
-      BIND (xsd:integer(?order_) AS ?order)
-    }
-    ?work wdt:P50 ?author_ ;
-          wdt:P31 wd:Q45182324 .
+    { SELECT ?author (COUNT(DISTINCT ?work) AS ?retractions) WHERE {
+      target: wdt:P50 ?author .
+      ?work wdt:P50 ?author ;
+            wdt:P31 wd:Q45182324 .
+    } GROUP BY ?author }
+
+    target: p:P50 ?authorStatement .
+    ?authorStatement ps:P50 ?author .
+    BIND (CONCAT("../author/", SUBSTR(STR(?author), 32), "#list-of-retracted-articles") AS ?authorUrl)
+    {{ sparql_helpers.labels(["?author"], languages) }}
+  } UNION {
+    target: p:P2093 ?authorStatement .
+    ?authorStatement ps:P2093 ?author .
+    BIND (CONCAT(?author, " ↗") AS ?authorLabel)
+    BIND (CONCAT("https://author-disambiguator.toolforge.org/names_oauth.php?doit=Look+for+author&name=", ENCODE_FOR_URI(?author)) AS ?authorUrl)
   }
-  UNION {
-    target: p:P2093 ?authorstring_statement .
-    ?authorstring_statement ps:P2093 ?author_
-    BIND (CONCAT(?author_, " ↗") AS ?author)
-    OPTIONAL {
-      ?authorstring_statement pq:P1545 ?order_ .
-      BIND (xsd:integer(?order_) AS ?order)
-    }
-    BIND (CONCAT("https://author-disambiguator.toolforge.org/names_oauth.php?doit=Look+for+author&name=", ENCODE_FOR_URI(?author_)) AS ?authorUrl)
-    BIND (target: AS ?work)
-  }
-  OPTIONAL {
-    ?author_ rdfs:label ?author .
-    FILTER (LANG(?author) = 'en')
-  }
-}
-GROUP BY ?order ?author ?authorUrl
-ORDER BY ?order
+
+  OPTIONAL { ?authorStatement pq:P1545 ?_order . }
+  BIND (xsd:integer(?_order) AS ?order)
+} ORDER BY ?order

--- a/scholia/app/templates/retraction_statements-with-retracted-references.sparql
+++ b/scholia/app/templates/retraction_statements-with-retracted-references.sparql
@@ -5,13 +5,9 @@ PREFIX pr: <http://www.wikidata.org/prop/reference/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT DISTINCT ?entity ?entityLabel ?entityUrl ?property ?propertyLabel ?value ?valueLabel WHERE {
-  {
-    SELECT DISTINCT ?entity ?p ?statement ?retracted WHERE {
-      BIND (target: AS ?retracted)
-      ?entity ?p ?statement .
-      ?statement prov:wasDerivedFrom/pr:P248 ?retracted .
-    }
-  }
+  ?entity ?p ?statement .
+  ?statement prov:wasDerivedFrom/pr:P248 target:  .
+
   ?p ^wikibase:claim ?property .
   ?statement ?ps ?value .
   ?ps ^wikibase:statementProperty ?property .

--- a/scholia/app/templates/topic_author-awards.sparql
+++ b/scholia/app/templates/topic_author-awards.sparql
@@ -1,23 +1,23 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-SELECT ?count ?award ?awardLabel (CONCAT("/award/", SUBSTR(STR(?award),32)) AS ?awardUrl) ?recipients ?recipientsUrl WHERE {
+SELECT ?count ?award ?awardLabel (CONCAT("/award/", SUBSTR(STR(?award), 32)) AS ?awardUrl) ?recipients ?recipientsUrl WHERE {
   {
-    SELECT (COUNT(?researcher) AS ?count) ?award (GROUP_CONCAT(DISTINCT ?researcher_label; SEPARATOR=", ") AS ?recipients) (CONCAT("../authors/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?researcher),32); SEPARATOR=",")) AS ?recipientsUrl) WHERE {
+    SELECT (COUNT(?researcher) AS ?count) ?award (GROUP_CONCAT(?researcherLabel; SEPARATOR=", ") AS ?recipients) (CONCAT("../authors/", GROUP_CONCAT(SUBSTR(STR(?researcher), 32); SEPARATOR=",")) AS ?recipientsUrl) WHERE {
       {
         SELECT DISTINCT ?researcher ?award WHERE {
-          # hint:Query hint:optimizer "None" .
           ?work wdt:P921 target: .
           ?work wdt:P50 ?researcher .
           ?researcher wdt:P166 ?award .
         }
-        LIMIT 100
       }
-      ?researcher rdfs:label ?researcher_label . FILTER (LANG(?researcher_label) = 'en')
+      {{ sparql_helpers.labels(["?researcher"], languages) }}
     }
     GROUP BY ?award
   }
-  ?award rdfs:label ?awardLabel . FILTER (LANG(?awardLabel) = 'en')
+
+  {{ sparql_helpers.labels(["?award"], languages) }}
 }
 GROUP BY ?count ?award ?awardLabel ?recipients ?recipientsUrl
 ORDER BY DESC(?count)

--- a/scholia/app/templates/topic_author-scores-graph.sparql
+++ b/scholia/app/templates/topic_author-scores-graph.sparql
@@ -1,9 +1,9 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:BubbleChart
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?score ?author (REPLACE(STR(?author), ".*/", "") AS ?authorLabel) WHERE {
+SELECT ?score ?author ?authorLabel WHERE {
   {
     SELECT ?author (SUM(?score_) AS ?score) WHERE {
       {
@@ -11,24 +11,19 @@ SELECT ?score ?author (REPLACE(STR(?author), ".*/", "") AS ?authorLabel) WHERE {
         BIND (20 AS ?score_)
       }
       UNION {
-        SELECT (3 AS ?score_) ?author WHERE {
-          ?work wdt:P50 ?author ;
-                wdt:P921/wdt:P279* target: .
-        }
+        ?work wdt:P50 ?author ;
+              wdt:P921/wdt:P279* target: .
+        BIND (3 AS ?score_)
       }
       UNION {
-        SELECT (1 AS ?score_) ?author WHERE {
-          ?cited_work wdt:P50 ?author .
-          ?citing_work wdt:P2860 ?cited_work .
-          ?citing_work wdt:P921/wdt:P279* target: .
-        }
+        ?citing_work wdt:P2860 ?work ;
+                     wdt:P921/wdt:P279* target: .
+        ?work wdt:P50 ?author .
+        BIND (1 AS ?score_)
       }
-    }
-    GROUP BY ?author
-    ORDER BY DESC(?score)
-    LIMIT 200
+    } GROUP BY ?author
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,jp,no,ru,sv,zh". }
-}
-ORDER BY DESC(?score)
-LIMIT 200
+
+  {{ sparql_helpers.labels(["?author"], languages) }}
+} ORDER BY DESC(?score)
+  LIMIT 200

--- a/scholia/app/templates/topic_author-scores.sparql
+++ b/scholia/app/templates/topic_author-scores.sparql
@@ -1,32 +1,42 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?score ?author ?authorLabel (CONCAT("/author/", SUBSTR(STR(?author),32)) AS ?authorUrl) ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work),32)) AS ?example_workUrl) WHERE {
+SELECT ?score ?author ?authorLabel (CONCAT("/author/", SUBSTR(STR(?author), 32)) AS ?authorUrl) ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl) WHERE {
   {
-    SELECT (SUM(?score_) AS ?score) ?author (SAMPLE(?work) AS ?example_work) WHERE {
+    SELECT (SUM(?score_) AS ?score) ?author (SAMPLE(?_example_work) AS ?example_work) (SAMPLE(?_example_workLabel) AS ?example_workLabel) WHERE {
       {
         ?author wdt:P101/wdt:P279* target: .
         BIND (20 AS ?score_)
       }
-      UNION {
-        SELECT (3 AS ?score_) ?author ?work WHERE {
-          ?work wdt:P50 ?author ;
-                wdt:P921/wdt:P279* target: .
+      UNION
+      {
+        {
+          SELECT (SUM(?workScore) AS ?score_) ?author (SAMPLE(?work) AS ?_example_work) WHERE {
+            {
+              ?work wdt:P50 ?author ;
+                    wdt:P921/wdt:P279* target: .
+              BIND (3 AS ?workScore)
+            }
+            UNION
+            {
+              ?citing_work wdt:P2860 ?work ;
+                          wdt:P921/wdt:P279* target: .
+              ?work wdt:P50 ?author .
+              BIND (1 AS ?workScore)
+            }
+          } GROUP BY ?author
         }
+
+        # Label of example work needs to be loaded when it is definitely bound, otherwise it
+        # tries include all existing labels. At the same time, it needs to be loaded after
+        # the works are sampled, as otherwise the title and IRI may refer to different works.
+
+        {{ sparql_helpers.labels(["?_example_work"], languages) }}
       }
-      UNION {
-        SELECT (1 AS ?score_) ?author ?work WHERE {
-          ?work wdt:P50 ?author .
-          ?citing_work wdt:P2860 ?work .
-          ?citing_work wdt:P921/wdt:P279* target: .
-        }
-      }
-    }
-    GROUP BY ?author
-    ORDER BY DESC(?score)
-    LIMIT 200
+    } GROUP BY ?author
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,jp,no,ru,sv,zh". }
-}
-ORDER BY DESC(?score)
+
+  {{ sparql_helpers.labels(["?author"], languages) }}
+} ORDER BY DESC(?score)
+  LIMIT 200

--- a/scholia/app/templates/topic_authors.sparql
+++ b/scholia/app/templates/topic_authors.sparql
@@ -1,3 +1,5 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
@@ -8,23 +10,18 @@ SELECT ?count ?author ?authorLabel ?authorDescription (CONCAT("/author/", SUBSTR
     SELECT ?author (COUNT(?work) AS ?count) WHERE {
       {
         ?work wdt:P921/wdt:P31*/wdt:P279* target: .
-      }
-      UNION {
+      } UNION {
         ?work wdt:P921/wdt:P361+ target: .
-      }
-      UNION {
+      } UNION {
         ?work wdt:P921/wdt:P1269+ target: .
       }
       ?work wdt:P50 ?author .
-    }
-    GROUP BY ?author
-    ORDER BY DESC(?count)
-    LIMIT 200
+    } GROUP BY ?author
+      LIMIT 200
   }
-  # Include optional ORCID iD
-  OPTIONAL {
-    ?author wdt:P496 ?orcid_ .
-  }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
-}
-ORDER BY DESC(?count)
+
+  OPTIONAL { ?author wdt:P496 ?orcid_ . }
+
+  {{ sparql_helpers.labels(["?author"], languages) }}
+  {{ sparql_helpers.descriptions(["?author"], languages) }}
+} ORDER BY DESC(?count)

--- a/scholia/app/templates/topic_co-occurring-map.sparql
+++ b/scholia/app/templates/topic_co-occurring-map.sparql
@@ -1,19 +1,20 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Map
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?location ?locationLabel ?geo ?example_work ?example_workLabel WHERE {
   {
     SELECT ?location ?geo (SAMPLE(?work) AS ?example_work) WHERE {
       # Find works that are marked with main subject of the topic.
       ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
-      # Identify co-occuring topic that is geo-locatable. 
+      # Identify co-occuring topic that is geo-locatable.
       ?work wdt:P921 ?location .
       ?location wdt:P625 ?geo .
     }
     GROUP BY ?location ?geo
   }
+
   # Label the results
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+  {{ sparql_helpers.labels(["?location", "?example_work"], languages) }}
 }

--- a/scholia/app/templates/topic_co-occurring.sparql
+++ b/scholia/app/templates/topic_co-occurring.sparql
@@ -1,14 +1,14 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Graph
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?topic1 ?topic1Label ?topic2 ?topic2Label WHERE {
   {
     SELECT (COUNT(DISTINCT ?work) AS ?count) ?topic1 ?topic2 WHERE {
       # Find works that are marked with main subject of the topic.
       ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
-      # Identify co-occuring topics. 
+      # Identify co-occuring topics.
       ?work wdt:P921 ?topic1, ?topic2 .
       # Exclude the topic it self
       FILTER (target: != ?topic1 && target: != ?topic2 && ?topic1 != ?topic2)
@@ -19,5 +19,6 @@ SELECT ?topic1 ?topic1Label ?topic2 ?topic2Label WHERE {
     # so we put a limit on the number of links displayed.
     LIMIT 400
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+
+  {{ sparql_helpers.labels(["?topic1", "?topic2"], languages) }}
 }

--- a/scholia/app/templates/topic_coauthor-graph.sparql
+++ b/scholia/app/templates/topic_coauthor-graph.sparql
@@ -1,43 +1,26 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Graph
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?author1 (REPLACE(STR(?author1), ".*/", "") AS ?author1Label) ?rgb ?author2 (REPLACE(STR(?author2), ".*/", "") AS ?author2Label) WHERE {
-  { # Limit the number of authors
-    SELECT (COUNT(?work) AS ?count1) ?author1 WHERE {
-      { # Find works with the topic
-        SELECT ?work WHERE {
-          ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
-        }
-      }
-      ?work wdt:P50 ?author1 .
-    }
-    GROUP BY ?author1
-    ORDER BY DESC(?count1)
-    LIMIT 25
-  }
-  { # Limit the number of coauthors
-    SELECT DISTINCT ?author2 ?author1 (COUNT(?work) AS ?count2) WHERE {
-      { # Find works with the topic
-        SELECT ?work WHERE {
-          ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
-        }
-      }
-      { # Limit the number of authors
+SELECT ?author1 ?author1Label ?rgb ?author2 ?author2Label WHERE {
+  {
+    SELECT ?author2 ?author1 (COUNT(?work) AS ?count2) WHERE {
+      # Find works with the topic
+      ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
+
+      {
         SELECT (COUNT(?work) AS ?count1) ?author1 WHERE {
-          { # Find works with the topic
-            SELECT ?work WHERE {
-              ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
-            }
-          }
+          # Find works with the topic
+          ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
           ?work wdt:P50 ?author1 .
         }
         GROUP BY ?author1
         ORDER BY DESC(?count1)
         LIMIT 25
       }
+
       ?work wdt:P50 ?author1, ?author2 .
       FILTER (?author1 != ?author2)
     }
@@ -45,9 +28,11 @@ SELECT ?author1 (REPLACE(STR(?author1), ".*/", "") AS ?author1Label) ?rgb ?autho
     ORDER BY DESC(?count2)
     LIMIT 250
   }
+
   OPTIONAL {
     ?author1 wdt:P21 ?gender1 .
   }
   BIND (IF(?gender1 = wd:Q6581097,"3182BD","E6550D") AS ?rgb)
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+
+  {{ sparql_helpers.labels(["?author1", "?author2"], languages) }}
 }

--- a/scholia/app/templates/topic_context.sparql
+++ b/scholia/app/templates/topic_context.sparql
@@ -1,12 +1,13 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 #defaultView:Graph
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 
-SELECT ?node (REPLACE(STR(?node), ".*/", "") AS ?nodeLabel) ?nodeImage ?childNode (REPLACE(STR(?childNode), ".*/", "") AS ?childNodeLabel) ?childNodeImage ?rgb WHERE {
+SELECT ?node ?nodeLabel ?nodeImage ?childNode ?childNodeLabel ?childNodeImage ?rgb WHERE {
   {
     {
       SELECT DISTINCT ?node ?childNode WHERE {
@@ -54,5 +55,6 @@ SELECT ?node (REPLACE(STR(?node), ".*/", "") AS ?nodeLabel) ?nodeImage ?childNod
     ?property wikibase:directClaim ?childNodeclaim .
     ?childNode ?childNodeclaim ?childNodeImage .
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }        
+
+  {{ sparql_helpers.labels(["?node", "?childNode"], languages) }}
 }

--- a/scholia/app/templates/topic_country-citation-graph.sparql
+++ b/scholia/app/templates/topic_country-citation-graph.sparql
@@ -1,22 +1,20 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Graph
-PREFIX target: <http://www.wikidata.org/entity/{{ q }}> 
-PREFIX bd: <http://www.bigdata.com/rdf#>
+PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT DISTINCT ?citing_country (REPLACE(STR(?citing_country), ".*/", "") AS ?citing_countryLabel) ?citing_flag ?cited_country (REPLACE(STR(?cited_country), ".*/", "") AS ?cited_countryLabel) ?cited_flag WHERE {
+SELECT DISTINCT ?citing_country ?citing_countryLabel ?citing_flag ?cited_country ?cited_countryLabel ?cited_flag WHERE {
   {
     SELECT DISTINCT ?cited_country ?citing_country (COUNT(?citing_country) AS ?count) WHERE {
-      ?citing_work wdt:P50 ?citing_author .
-      ?citing_work wdt:P921 target: .
-      ?cited_work wdt:P921 target: .
-      ?citing_work wdt:P2860 ?cited_work .
-      ?cited_work wdt:P50 ?cited_author .
+      ?citing_work wdt:P921 target: ;
+                   wdt:P50 ?citing_author ;
+                   wdt:P2860 ?cited_work .
+      ?cited_work wdt:P921 target: ;
+                  wdt:P50 ?cited_author .
+
       FILTER (?citing_work != ?cited_work)
-      FILTER NOT EXISTS {
-        ?citing_work wdt:P50 ?author .
-        ?citing_work wdt:P2860 ?cited_work .
-        ?cited_work wdt:P50 ?author .
-      }
+      FILTER (?citing_author != ?cited_author)
+
       ?citing_author (wdt:P108 | wdt:P1416) ?citing_organization .
       ?cited_author (wdt:P108 | wdt:P1416) ?cited_organization .
       ?cited_organization wdt:P17 ?cited_country .
@@ -30,5 +28,6 @@ SELECT DISTINCT ?citing_country (REPLACE(STR(?citing_country), ".*/", "") AS ?ci
   }
   ?cited_country wdt:P41 ?cited_flag .
   ?citing_country wdt:P41 ?citing_flag .
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }        
+
+  {{ sparql_helpers.labels(["?citing_country", "?cited_country"], languages) }}
 }

--- a/scholia/app/templates/topic_earliest-published-works.sparql
+++ b/scholia/app/templates/topic_earliest-published-works.sparql
@@ -1,28 +1,29 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-SELECT ?date ?work (REPLACE(STR(?work), ".*/", "") AS ?workLabel) (CONCAT("/work/", SUBSTR(STR(?work),32)) AS ?workUrl) ?topicsUrl ?topics WHERE {
+SELECT ?date ?work ?workLabel (CONCAT("/work/", SUBSTR(STR(?work),32)) AS ?workUrl) ?topicsUrl ?topics WHERE {
   {
-    SELECT (MAX(?dates) AS ?datetime) ?work (GROUP_CONCAT(DISTINCT ?topic_label; SEPARATOR=" // ") AS ?topics) (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic),32); SEPARATOR=",")) AS ?topicsUrl) WHERE {
+    SELECT (MAX(?dates) AS ?datetime) ?work (GROUP_CONCAT(DISTINCT ?topicLabel; SEPARATOR=" // ") AS ?topics) (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic), 32); SEPARATOR=",")) AS ?topicsUrl) WHERE {
       {
         SELECT DISTINCT ?work WHERE {
           ?work wdt:P921/(wdt:P361+ | wdt:P1269+ | (wdt:P31*/wdt:P279*)) target: .
         }
       }
-      ?work wdt:P921 ?topic .
-      ?work wdt:P577 ?dates .
+      ?work wdt:P921 ?topic ;
+            wdt:P577 ?dates .
       FILTER (!ISBLANK(?dates)) .
-      ?topic rdfs:label ?topic_label . FILTER (LANG(?topic_label) = 'en')
+
+      {{ sparql_helpers.labels(["?topic"], languages) }}
     }
     GROUP BY ?work
   }
   # There is a problem with BC dates
   # BIND(xsd:date(?datetime) AS ?date)
   BIND (REPLACE(STR(?datetime), 'T.*', '') AS ?date)
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+
+  {{ sparql_helpers.labels(["?work"], languages) }}
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY ASC(?date)

--- a/scholia/app/templates/topic_most-cited-authors.sparql
+++ b/scholia/app/templates/topic_most-cited-authors.sparql
@@ -1,9 +1,8 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?number_of_citations ?author ?authorLabel (CONCAT("/author/", SUBSTR(STR(?author),32)) AS ?authorUrl) ?cited_work_example ?cited_work_exampleLabel (CONCAT("/work/", SUBSTR(STR(?cited_work_example),32)) AS ?cited_work_exampleUrl) WHERE {
-  # Label the results
   { # Find cited works
     SELECT (COUNT(?work) AS ?number_of_citations) ?author (SAMPLE(?cited_work) AS ?cited_work_example) WHERE {
       { # Find works about the topic
@@ -16,7 +15,9 @@ SELECT ?number_of_citations ?author ?authorLabel (CONCAT("/author/", SUBSTR(STR(
     }
     GROUP BY ?author
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+
+  # Label the results
+  {{ sparql_helpers.labels(["?author", "?cited_work_example"], languages) }}
 }
 ORDER BY DESC(?number_of_citations)
 LIMIT 200

--- a/scholia/app/templates/topic_organization-map.sparql
+++ b/scholia/app/templates/topic_organization-map.sparql
@@ -1,11 +1,11 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Map
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?organization (REPLACE(STR(?organization), ".*/", "") AS ?organizationLabel) ?geo ?count ?layer WHERE {
+SELECT ?organization ?organizationLabel ?geo ?count ?layer WHERE {
   {
     SELECT DISTINCT ?organization ?geo (COUNT(DISTINCT ?work) AS ?count) WHERE {
       {
@@ -33,6 +33,7 @@ SELECT ?organization (REPLACE(STR(?organization), ".*/", "") AS ?organizationLab
     LIMIT 2000
   }
   BIND (IF((?count < 1),"No results",IF((?count < 2),"1 result",IF((?count < 11),"1 < results ≤ 10",IF((?count < 101),"10 < results ≤ 100",IF((?count < 1001),"100 < results ≤ 1000",IF((?count < 10001),"1000 < results ≤ 10000","10000 or more results")))))) AS ?layer)
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }        
+
+  {{ sparql_helpers.labels(["?organization"], languages) }}
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/topic_publications-per-year.sparql
+++ b/scholia/app/templates/topic_publications-per-year.sparql
@@ -1,12 +1,15 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:BarChart
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-SELECT (STR(?year_) AS ?year) (COUNT(?work) AS ?number_of_publications)
-# Work type used to color the bar chart
-?type WHERE {
+SELECT
+  (STR(?year_) AS ?year)
+  (COUNT(?work) AS ?number_of_publications)
+  # Work type used to color the bar chart
+  (?article_typeLabel AS ?type)
+WHERE {
   {
     { # Find works with the topic. Also report the year
       SELECT ?work (MIN(?years) AS ?year_) (1 AS ?dummy) (SAMPLE(?article_type_) AS ?article_type) WHERE {
@@ -17,34 +20,25 @@ SELECT (STR(?year_) AS ?year) (COUNT(?work) AS ?number_of_publications)
       }
       GROUP BY ?work
     }
-    ?article_type rdfs:label ?type . FILTER (LANG(?type) = "en")
+    {{ sparql_helpers.labels(["?article_type"], languages) }}
   }
   UNION {
-    {
-      SELECT ?year_ WHERE {
-        # default values = 0
-        ?year_item wdt:P31 wd:Q577 .
-        ?year_item wdt:P585 ?date .
-        BIND (YEAR(?date) AS ?year_)
-      }
-    }
-    BIND ("_" AS ?type)
+    [] wdt:P31 wd:Q577 ;
+       wdt:P585 ?date .
+    BIND (YEAR(?date) AS ?year_)
+    BIND ("_" AS ?article_typeLabel)
   }
+
   { # Find earliest publication year
     SELECT (MIN(?year_) AS ?earliest_year) WHERE {
-      { # Find works with the topic. Also report the year
-        SELECT ?work (MIN(?years) AS ?year_) (1 AS ?dummy) (SAMPLE(?article_type_) AS ?article_type) WHERE {
-          ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
-          ?work wdt:P577 ?dates .
-          BIND (YEAR(?dates) AS ?years) .
-          ?work wdt:P31 ?article_type_ .
-        }
-        GROUP BY ?work
-      }
+      ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
+      ?work wdt:P577 ?date .
+      BIND (YEAR(?date) AS ?year_) .
     }
-    GROUP BY ?dummy
   }
-  BIND (YEAR(NOW() 
-) AS ?this_year ) FILTER ( ?year_ >= ?earliest_year && ?year_ <= ?this_year && ?year_ >= YEAR ( "1900-01-01" ^^ xsd:dateTime ) )}
-GROUP BY ?year_ ?type
+
+  BIND (YEAR(NOW()) AS ?this_year)
+  FILTER (?year_ >= ?earliest_year && ?year_ <= ?this_year && ?year_ >= 1900)
+}
+GROUP BY ?year_ ?article_typeLabel
 ORDER BY ?year

--- a/scholia/app/templates/topic_recently-published-works.sparql
+++ b/scholia/app/templates/topic_recently-published-works.sparql
@@ -1,12 +1,12 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-SELECT ?date ?work (REPLACE(STR(?work), ".*/", "") AS ?workLabel) (CONCAT("/work/", SUBSTR(STR(?work),32)) AS ?workUrl) ?topicsUrl ?topics WHERE {
+SELECT ?date ?work ?workLabel (CONCAT("/work/", SUBSTR(STR(?work),32)) AS ?workUrl) ?topicsUrl ?topics WHERE {
   {
-    SELECT (MAX(?dates) AS ?datetime) ?work (GROUP_CONCAT(DISTINCT ?topic_label; SEPARATOR=" // ") AS ?topics) (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic),32); SEPARATOR=",")) AS ?topicsUrl) WHERE {
+    SELECT (MAX(?dates) AS ?datetime) ?work (GROUP_CONCAT(DISTINCT ?topicLabel; SEPARATOR=" // ") AS ?topics) (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic),32); SEPARATOR=",")) AS ?topicsUrl) WHERE {
       {
         SELECT DISTINCT ?work WHERE {
           ?work wdt:P921/(wdt:P361+ | wdt:P1269+ | (wdt:P31*/wdt:P279*)) target: .
@@ -16,14 +16,15 @@ SELECT ?date ?work (REPLACE(STR(?work), ".*/", "") AS ?workLabel) (CONCAT("/work
       OPTIONAL {
         ?work wdt:P577 ?dates .
       }
-      ?topic rdfs:label ?topic_label . FILTER (LANG(?topic_label) = 'en')
+      {{ sparql_helpers.labels(["?topic"], languages) }}
     }
     GROUP BY ?work
   }
   # There is a problem with BC dates
   # BIND(xsd:date(?datetime) AS ?date)
   BIND (REPLACE(STR(?datetime), 'T.*', '') AS ?date)
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+
+  {{ sparql_helpers.labels(["?work"], languages) }}
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY DESC(?date)

--- a/scholia/app/templates/topic_top-cited.sparql
+++ b/scholia/app/templates/topic_top-cited.sparql
@@ -1,25 +1,26 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?count ?cited_work ?cited_workLabel (CONCAT("/work/", SUBSTR(STR(?cited_work),32)) AS ?cited_workUrl) WHERE {
+SELECT ?count ?cited_work ?cited_workLabel (CONCAT("/work/", SUBSTR(STR(?cited_work), 32)) AS ?cited_workUrl) WHERE {
   {
     SELECT (COUNT(?work) AS ?count) ?cited_work WHERE {
       {
         ?work wdt:P921/wdt:P31*/wdt:P279* target: .
-      }
-      UNION {
+      } UNION {
         ?work wdt:P921/wdt:P361+ target: .
-      }
-      UNION {
+      } UNION {
         ?work wdt:P921/wdt:P1269+ target: .
       }
       ?work wdt:P2860 ?cited_work .
     }
     GROUP BY ?cited_work
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
+
+  {{ sparql_helpers.labels(["?cited_work"], languages) }}
 }
 ORDER BY DESC(?count)
 LIMIT 200

--- a/scholia/app/templates/topic_topics.sparql
+++ b/scholia/app/templates/topic_topics.sparql
@@ -1,9 +1,11 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?count (CONCAT("/topics/{{ q }},", SUBSTR(STR(?topic),32)) AS ?countUrl) ?topic ?topicLabel (CONCAT("/topic/", SUBSTR(STR(?topic),32)) AS ?topicUrl) ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work),32)) AS ?example_workUrl) WHERE {
+SELECT ?count (CONCAT("/topics/{{ q }},", SUBSTR(STR(?topic), 32)) AS ?countUrl) ?topic ?topicLabel (CONCAT("/topic/", SUBSTR(STR(?topic),32)) AS ?topicUrl) ?example_work ?example_workLabel (CONCAT("/work/", SUBSTR(STR(?example_work), 32)) AS ?example_workUrl) WHERE {
   # Label the results
   {
     SELECT (COUNT(?work) AS ?count) ?topic (SAMPLE(?work) AS ?example_work) WHERE {
@@ -16,6 +18,7 @@ SELECT ?count (CONCAT("/topics/{{ q }},", SUBSTR(STR(?topic),32)) AS ?countUrl) 
     }
     GROUP BY ?topic
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
+
+  {{ sparql_helpers.labels(["?topic", "?example_work"], languages) }}
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/topic_uses.sparql
+++ b/scholia/app/templates/topic_uses.sparql
@@ -1,8 +1,8 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?count ?use ?useLabel (CONCAT("/use/", SUBSTR(STR(?use),32)) AS ?useUrl) ("🔎" AS ?zoom) (CONCAT(SUBSTR(STR(target:),32), "/use/", SUBSTR(STR(?use),32)) AS ?zoomUrl) ?useDescription ?example_work ?example_workLabel WHERE {
+SELECT ?count ?use ?useLabel (CONCAT("/use/", SUBSTR(STR(?use), 32)) AS ?useUrl) ("🔎" AS ?zoom) (CONCAT(SUBSTR(STR(target:), 32), "/use/", SUBSTR(STR(?use), 32)) AS ?zoomUrl) ?useDescription ?example_work ?example_workLabel WHERE {
   {
     SELECT (COUNT(?work) AS ?count) ?use (SAMPLE(?work) AS ?example_work) {
       ?work wdt:P921 target: ;
@@ -10,6 +10,8 @@ SELECT ?count ?use ?useLabel (CONCAT("/use/", SUBSTR(STR(?use),32)) AS ?useUrl) 
     }
     GROUP BY ?use
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+
+  {{ sparql_helpers.labels(["?use", "?example_work"], languages) }}
+  {{ sparql_helpers.descriptions(["?use"], languages) }}
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/topic_venues.sparql
+++ b/scholia/app/templates/topic_venues.sparql
@@ -1,8 +1,8 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?count ?short_name ?venue ?venueLabel (CONCAT("/venue/", SUBSTR(STR(?venue),32)) AS ?venueUrl) WHERE {
   {
     SELECT (COUNT(?work) AS ?count) ?venue (SAMPLE(?short_name_) AS ?short_name) WHERE {
@@ -22,7 +22,8 @@ SELECT ?count ?short_name ?venue ?venueLabel (CONCAT("/venue/", SUBSTR(STR(?venu
     }
     GROUP BY ?venue
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
+
+  {{ sparql_helpers.labels(["?venue"], languages) }}
 }
 ORDER BY DESC(?count)
 LIMIT 200


### PR DESCRIPTION
### Description
Uses the sparql macros from #20 to update the queries for the retraction and topic aspects.   

### Testing
- http://127.0.0.1:8100/topic/Q202864
- http://127.0.0.1:8100/retraction/Q21563359

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
