### PR TITLE
Update queries of work aspect

### DIFF
--- a/scholia/app/templates/work-cito-intention_incoming.sparql
+++ b/scholia/app/templates/work-cito-intention_incoming.sparql
@@ -1,13 +1,13 @@
-PREFIX bd: <http://www.bigdata.com/rdf#>
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
+PREFIX target1: <http://www.wikidata.org/prop/{{ q }}>
+PREFIX target2: <http://www.wikidata.org/prop/{{ q2 }}>
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 PREFIX ps: <http://www.wikidata.org/prop/statement/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?citingArticle (REPLACE(STR(?citingArticle), ".*/", "") AS ?citingArticleLabel) ?intention ?intentionLabel (CONCAT("/cito/", SUBSTR(STR(?intention),32)) AS ?intentionUrl) WHERE {
-  #  VALUES ?CITEDARTICLE { wd:{{ q }} }
-  #  VALUES ?intention { wd:{{ q2 }} }
+SELECT ?citingArticle ?citingArticleLabel ?intention ?intentionLabel (CONCAT("/cito/", SUBSTR(STR(?intention),32)) AS ?intentionUrl) WHERE {
   ?citingArticle p:P2860 ?citationStatement .
-  ?citationStatement pq:P3712 ?intention ;
-                     ps:P2860 ?CITEDARTICLE .
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+  ?citationStatement pq:P3712 target2: ;
+                     ps:P2860 target1: .
+  {{ sparql_helpers.labels(["?citingArticle", "?intention"], languages) }}
 }

--- a/scholia/app/templates/work-curation_missing-orcid.sparql
+++ b/scholia/app/templates/work-curation_missing-orcid.sparql
@@ -1,11 +1,11 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT DISTINCT ?author ?authorLabel ?authorDescription (CONCAT("/author/", SUBSTR(STR(?author),32)) AS ?authorUrl) ("ORCID search ↗" AS ?orcid_search) (CONCAT("https://orcid.org/orcid-search/search/?searchQuery=", ENCODE_FOR_URI(?authorLabel)) AS ?orcid_searchUrl) WHERE {
   target: wdt:P50 ?author .
   FILTER NOT EXISTS {
     ?author wdt:P496 ?orcid .
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+  {{ sparql_helpers.labels(["?author"], languages) }}
 }

--- a/scholia/app/templates/work-index_recently-retracted-works.sparql
+++ b/scholia/app/templates/work-index_recently-retracted-works.sparql
@@ -1,13 +1,13 @@
-PREFIX bd: <http://www.bigdata.com/rdf#>
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 PREFIX ps: <http://www.wikidata.org/prop/statement/>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 SELECT DISTINCT ?retracted_work ?retracted_workLabel (CONCAT("/work/", SUBSTR(STR(?retracted_work),32)) AS ?retracted_workUrl) ?date ?retraction ?retractionLabel (CONCAT("/work/", SUBSTR(STR(?retraction),32)) AS ?retractionUrl) WHERE {
-  { # Find retracted papers indicated by instance of retracted paper, 
+  { # Find retracted papers indicated by instance of retracted paper,
     # by retraction notice property or by significant event
     SELECT DISTINCT ?retracted_work WHERE {
       {
@@ -24,6 +24,7 @@ SELECT DISTINCT ?retracted_work ?retracted_workLabel (CONCAT("/work/", SUBSTR(ST
   OPTIONAL {
     ?retracted_work wdt:P5824 ?retraction .
     ?retraction wdt:P577 ?retraction_datetime
+    {{ sparql_helpers.labels(["?retraction"], languages) }}
   }
   OPTIONAL {
     ?retracted_work p:P793 [
@@ -32,7 +33,7 @@ SELECT DISTINCT ?retracted_work ?retracted_workLabel (CONCAT("/work/", SUBSTR(ST
     ]
   }
   BIND (COALESCE(xsd:date(COALESCE(?retraction_datetime, ?keyevent_datetime)), "Unknown date") AS ?date)
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+  {{ sparql_helpers.labels(["?retracted_work"], languages) }}
 }
 ORDER BY DESC(?date)
 LIMIT 500

--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -10,7 +10,7 @@
 {{ sparql_to_table('citations') }}
 {{ sparql_to_table('cited-works') }}
 {{ sparql_to_table('cited-work-authors') }}
-{{ sparql_to_table('wikipedia-mentions') }}
+{# {{ sparql_to_table('wikipedia-mentions') }} #}
 {{ sparql_to_table('statements') }}
 
 {{ sparql_to_iframe('topic-scores') }}
@@ -133,9 +133,9 @@ Recent citations to the work
 </div>
 
 
-<h2 id="wikipedia-mentions">Wikipedia mentions</h2>
+<!-- <h2 id="wikipedia-mentions">Wikipedia mentions</h2> -->
 
-<table class="table table-hover" id="wikipedia-mentions-table"></table>
+<!-- <table class="table table-hover" id="wikipedia-mentions-table"></table> -->
 
 
 

--- a/scholia/app/templates/work_citation-graph.sparql
+++ b/scholia/app/templates/work_citation-graph.sparql
@@ -1,75 +1,64 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Graph
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 PREFIX ps: <http://www.wikidata.org/prop/statement/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 SELECT ?citing_work ?citing_workLabel ?rgb ?cited_work ?cited_workLabel WHERE {
   {
     SELECT (COUNT(*) AS ?count) ?citing_work WHERE {
-      target: (^wdt:P2860 | wdt:P2860)/(^wdt:P2860 | wdt:P2860)? ?citing_work .
+      { target: ^wdt:P2860/^wdt:P2860 ?citing_work }
+      UNION
+      { target: wdt:P2860/^wdt:P2860 ?citing_work }
+      UNION
+      { target: ^wdt:P2860/wdt:P2860 ?citing_work }
+      UNION
+      { target: wdt:P2860/wdt:P2860 ?citing_work }
     }
     GROUP BY ?citing_work
     ORDER BY DESC(?count)
     LIMIT 40
   }
   {
-    SELECT (MAX(?count) AS ?max_count) WHERE {
-      {
-        SELECT (COUNT(*) AS ?count) ?citing_work WHERE {
-          target: (^wdt:P2860 | wdt:P2860)/(^wdt:P2860 | wdt:P2860)? ?citing_work .
-        }
-        GROUP BY ?citing_work
-        ORDER BY DESC(?count)
-        LIMIT 40
-      }
-      BIND (1 AS ?dummy)
-    }
-    GROUP BY ?dummy
-  }
-  {
     SELECT (COUNT(*) AS ?count_) ?cited_work WHERE {
-      target: (^wdt:P2860 | wdt:P2860)/(^wdt:P2860 | wdt:P2860)? ?cited_work .
+      { target: ^wdt:P2860/^wdt:P2860 ?cited_work }
+      UNION
+      { target: wdt:P2860/^wdt:P2860 ?cited_work }
+      UNION
+      { target: ^wdt:P2860/wdt:P2860 ?cited_work }
+      UNION
+      { target: wdt:P2860/wdt:P2860 ?cited_work }
     }
     GROUP BY ?cited_work
     ORDER BY DESC(?count_)
     LIMIT 40
   }
   ?citing_work wdt:P2860 ?cited_work .
-  BIND (STR(xsd:integer(99 * (1 - ?count / ?max_count))) AS ?grey)
-  BIND (CONCAT(SUBSTR("0",1,2 - STRLEN(?grey)), ?grey) AS ?padded_grey)
+  BIND (STR(xsd:integer(99 * (1 - ?count / MAX(?count)))) AS ?grey)
+  BIND (CONCAT(SUBSTR("0", STRLEN(?grey)), ?grey) AS ?padded_grey)
   BIND (CONCAT(?padded_grey, ?padded_grey, ?padded_grey) AS ?rgb)
   {
-    ?citing_work (p:P50) ?citing_author_statement .
-    ?citing_author_statement pq:P1545 "1" .
-    ?citing_author_statement ps:P50 ?citing_author .
-    ?citing_author rdfs:label ?citing_author_name .
-    FILTER (LANG(?citing_author_name) = 'en')
+    ?citing_work p:P50 [ pq:P1545 "1"; ps:P50 ?citing_author ]
+    {{ sparql_helpers.labels(["?citing_author"], languages) }}
   }
   UNION {
-    ?citing_work (p:P2093) ?citing_author_statement .
-    ?citing_author_statement pq:P1545 "1" .
-    ?citing_author_statement ps:P2093 ?citing_author_name .
+    ?citing_work p:P2093 [ pq:P1545 "1" ; ps:P2093 ?citing_authorLabel ]
   }
   {
-    ?cited_work (p:P50) ?cited_author_statement .
-    ?cited_author_statement pq:P1545 "1" .
-    ?cited_author_statement ps:P50 ?cited_author .
-    ?cited_author rdfs:label ?cited_author_name .
-    FILTER (LANG(?cited_author_name) = 'en')
+    ?cited_work p:P50 [ pq:P1545 "1" ; ps:P50 ?cited_author ]
+    {{ sparql_helpers.labels(["?cited_author"], languages) }}
   }
   UNION {
-    ?cited_work (p:P2093) ?cited_author_statement .
-    ?cited_author_statement pq:P1545 "1" .
-    ?cited_author_statement ps:P2093 ?cited_author_name .
+    ?cited_work p:P2093 [ pq:P1545 "1" ; ps:P2093 ?cited_authorLabel ]
   }
   ?citing_work wdt:P577 ?citing_date .
   ?cited_work wdt:P577 ?cited_date .
   BIND (YEAR(?citing_date) AS ?citing_year)
   BIND (YEAR(?cited_date) AS ?cited_year)
-  BIND (CONCAT(?citing_author_name, ", ", STR(?citing_year)) AS ?citing_workLabel)
-  BIND (CONCAT(?cited_author_name, ", ", STR(?cited_year)) AS ?cited_workLabel)
+  BIND (CONCAT(?citing_authorLabel, ", ", STR(?citing_year)) AS ?citing_workLabel)
+  BIND (CONCAT(?cited_authorLabel, ", ", STR(?cited_year)) AS ?cited_workLabel)
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/work_citations-per-year.sparql
+++ b/scholia/app/templates/work_citations-per-year.sparql
@@ -1,11 +1,25 @@
 #defaultView:BarChart
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
+PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 SELECT (STR(?year_) AS ?year) (SUM(?count_) AS ?count) ?kind WHERE {
   {
-    VALUES ?year_ { 2004 2005 2006 2007 2008 2009 2010 2011 2012 2013 2014 2015 2016 2017 2018 2019 2020 2021 2022 2023 }
+    VALUES ?year_class { wd:Q577 wd:Q3186692 }
+    [] wdt:P31 ?year_class ;
+       wdt:P585 ?date .
+    BIND (YEAR(?date) AS ?year_)
     BIND (0 AS ?count_)
     BIND ("_" AS ?kind)
+
+    {
+      SELECT (MIN(?year) as ?earliest_year) WHERE {
+        target: wdt:P2860|^wdt:P2860 ?work .
+        ?work wdt:P577 ?date .
+        BIND (YEAR(?date) AS ?year)
+      }
+    }
+
+    FILTER(?year_ >= ?earliest_year && ?year_ <= YEAR(NOW()))
   }
   UNION {
     SELECT ?year_ (COUNT(DISTINCT ?citing_work) AS ?count_) ?kind WHERE {

--- a/scholia/app/templates/work_citations.sparql
+++ b/scholia/app/templates/work_citations.sparql
@@ -1,12 +1,11 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
+#title: List of works that is cited by the specified work
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-# List of works that is cited by the specified work
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-SELECT ?citations ?publication_date ?citing_work (REPLACE(STR(?citing_work), ".*/", "") AS ?citing_workLabel) WHERE {
-  # Label the result
+SELECT ?publication_date ?citations  ?citing_work ?citing_workLabel WHERE {
   {
     SELECT (MIN(?date) AS ?publication_date) (COUNT(?citing_citing_work) AS ?citations) ?citing_work WHERE {
       # Find works that cite the queried work
@@ -20,11 +19,12 @@ SELECT ?citations ?publication_date ?citing_work (REPLACE(STR(?citing_work), ".*
         ?citing_citing_work wdt:P2860 ?citing_work
       }
     }
-    GROUP BY ?citing_work
+    GROUP BY ?citing_work ?citing_workLabel
     # Limit the number of results to avoid downloading too much data
-    ORDER BY DESC(?citations) DESC(?date)
+    ORDER BY DESC(?citations) DESC(?publication_date)
     LIMIT 1000
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
+  # Label the result
+  {{ sparql_helpers.labels(["?citing_work"], languages) }}
 }
 ORDER BY DESC(?citations) DESC(?publication_date)

--- a/scholia/app/templates/work_cited-work-authors.sparql
+++ b/scholia/app/templates/work_cited-work-authors.sparql
@@ -1,11 +1,10 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
+#title: List of authors with works that are cited by the specified work
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-# List of authors with works that are cited by the specified work
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?cited_works ?author ?authorLabel ?authorDescription (CONCAT("/author/", SUBSTR(STR(?author),32)) AS ?authorUrl) ?cited_work_example ?cited_work_exampleLabel (CONCAT("/work/", SUBSTR(STR(?cited_work_example),32)) AS ?cited_work_exampleUrl) WHERE {
-  # Label the result
   {
     SELECT (COUNT(?cited_work) AS ?cited_works) ?author (SAMPLE(?cited_work) AS ?cited_work_example) WHERE {
       # Find works that are cited by the queried work
@@ -17,6 +16,8 @@ SELECT ?cited_works ?author ?authorLabel ?authorDescription (CONCAT("/author/", 
     ORDER BY DESC(?cited_works)
     LIMIT 1000
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+  # Label the result
+  {{ sparql_helpers.labels(["?author", "?cited_work_example"], languages) }}
+  {{ sparql_helpers.descriptions(["?author"], languages) }}
 }
 ORDER BY DESC(?cited_works)

--- a/scholia/app/templates/work_cited-works.sparql
+++ b/scholia/app/templates/work_cited-works.sparql
@@ -1,15 +1,14 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
+#title: List of works that is cited by the specified work
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-# List of works that is cited by the specified work
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 PREFIX ps: <http://www.wikidata.org/prop/statement/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-SELECT ?citations ?publication_date ?cited_work (REPLACE(STR(?cited_work), ".*/", "") AS ?cited_workLabel) (GROUP_CONCAT(DISTINCT ?intentionLabel; SEPARATOR=", ") AS ?intentions) WHERE {
+SELECT ?citations ?publication_date ?cited_work ?cited_workLabel (GROUP_CONCAT(DISTINCT ?intentionLabel; SEPARATOR=", ") AS ?intentions) WHERE {
   {
     SELECT (MIN(?date) AS ?publication_date) (COUNT(DISTINCT ?citing_cited_work) AS ?citations) ?cited_work WHERE {
       target: wdt:P2860 ?cited_work .
@@ -27,9 +26,9 @@ SELECT ?citations ?publication_date ?cited_work (REPLACE(STR(?cited_work), ".*/"
     target: p:P2860 ?citationStatement .
     ?citationStatement pq:P3712 ?intention ;
                        ps:P2860 ?cited_work .
-    ?intention rdfs:label ?intentionLabel . FILTER (LANG(?intentionLabel) = "en")
+    {{ sparql_helpers.labels(["?intention"], languages) }}
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
+  {{ sparql_helpers.labels(["?cited_work"], languages) }}
 }
 GROUP BY ?citations ?publication_date ?cited_work ?cited_workLabel
 ORDER BY DESC(?citations) DESC(?date)

--- a/scholia/app/templates/work_cito-incoming-chart.sparql
+++ b/scholia/app/templates/work_cito-incoming-chart.sparql
@@ -1,19 +1,18 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:BubbleChart
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 PREFIX ps: <http://www.wikidata.org/prop/statement/>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?intention (REPLACE(STR(?intention), ".*/", "") AS ?intentionLabel) (COUNT(DISTINCT ?citingArticle) AS ?count) WHERE {
-  VALUES ?CITEDARTICLE { target: }
+SELECT ?intention ?intentionLabel (COUNT(DISTINCT ?citingArticle) AS ?count) WHERE {
   ?citingArticle p:P2860 ?citationStatement .
   ?citationStatement pq:P3712 ?intention ;
-                     ps:P2860 ?CITEDARTICLE .
+                     ps:P2860 target: .
   ?intention wdt:P31 wd:Q96471816 .
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+  {{ sparql_helpers.labels(["?intention"], languages) }}
 }
 GROUP BY ?intention ?intentionLabel
 ORDER BY DESC(?count)

--- a/scholia/app/templates/work_cito-incoming.sparql
+++ b/scholia/app/templates/work_cito-incoming.sparql
@@ -1,23 +1,21 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 PREFIX ps: <http://www.wikidata.org/prop/statement/>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?intention (REPLACE(STR(?intention), ".*/", "") AS ?intentionLabel) (CONCAT("/cito/", SUBSTR(STR(?intention),32)) AS ?intentionUrl) ?count ?example_work_for_intention ?example_work_for_intentionLabel WHERE {
+SELECT ?intention ?intentionLabel (CONCAT("/cito/", SUBSTR(STR(?intention),32)) AS ?intentionUrl) ?count ?example_work_for_intention ?example_work_for_intentionLabel WHERE {
   {
     SELECT ?intention (COUNT(DISTINCT ?citingArticle) AS ?count) (SAMPLE(?citingArticle) AS ?example_work_for_intention) {
-      VALUES ?CITEDARTICLE { target: }
       ?citingArticle p:P2860 ?citationStatement .
       ?citationStatement pq:P3712 ?intention ;
-                         ps:P2860 ?CITEDARTICLE .
+                         ps:P2860 target: .
       ?intention wdt:P31 wd:Q96471816 .
     }
     GROUP BY ?intention
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+  {{ sparql_helpers.labels(["?intention", "?example_work_for_intention"], languages) }}
 }
-GROUP BY ?intention ?intentionLabel ?count ?example_work_for_intention ?example_work_for_intentionLabel
 ORDER BY DESC(?count)

--- a/scholia/app/templates/work_data.sparql
+++ b/scholia/app/templates/work_data.sparql
@@ -1,320 +1,288 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 PREFIX ps: <http://www.wikidata.org/prop/statement/>
 PREFIX psv: <http://www.wikidata.org/prop/statement/value/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT DISTINCT ?description ?value ?valueUrl WHERE {
-  BIND (target: AS ?work)
   {
     BIND (1 AS ?order)
     BIND ("Title" AS ?description)
-    ?work wdt:P1476 ?value .
+    target: wdt:P1476 ?value .
   }
   UNION {
     BIND (1.5 AS ?order)
     BIND ("Type" AS ?description)
-    ?work wdt:P31 ?iri .
-    BIND (SUBSTR(STR(?iri),32) AS ?q)
-    ?iri rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (COALESCE(?value_string, ?q) AS ?value)
+    target: wdt:P31 ?_value .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../", ?qid) AS ?valueUrl)
   }
   UNION {
-    SELECT (2 AS ?order) ("Authors" AS ?description) (GROUP_CONCAT(?value_; SEPARATOR=", ") AS ?value) (CONCAT("../authors/", GROUP_CONCAT(?q; SEPARATOR=",")) AS ?valueUrl) {
-      BIND (1 AS ?dummy)
-      {
-        # GROUP_CONCAT does not order by standard but BlazeGraph seems to order
-        # so we are hoping the sorting is correct here.
-        SELECT ?value_ ?q WHERE {
-          target: p:P50 ?author_statement .
-          ?author_statement ps:P50 ?author .
-          BIND (SUBSTR(STR(?author),32) AS ?q)
-          ?author_statement pq:P1545 ?order .
-          BIND (xsd:integer(?order) AS ?n)
-          ?author rdfs:label ?value_string .
-          FILTER (LANG(?value_string) = 'en')
-          BIND (COALESCE(?value_string, ?q) AS ?value_)
+    {
+      SELECT (2 AS ?order) ("Authors" AS ?description) (GROUP_CONCAT(?_value; SEPARATOR=", ") AS ?value) (CONCAT("../authors/", GROUP_CONCAT(?qid; SEPARATOR=",")) AS ?valueUrl) {
+        {
+          # GROUP_CONCAT does not order by standard but BlazeGraph seems to order
+          # so we are hoping the sorting is correct here.
+          SELECT ?_value ?qid WHERE {
+            target: p:P50 [ ps:P50 ?author; pq:P1545 ?order ] .
+            {{ sparql_helpers.labels(["?author"], languages) }}
+            BIND (SUBSTR(STR(?author), 32) AS ?qid)
+            BIND (COALESCE(?authorLabel, ?qid) AS ?_value)
+            BIND (xsd:integer(?order) AS ?n)
+          }
+          ORDER BY ?n
         }
-        ORDER BY ?n
       }
     }
-    GROUP BY ?dummy
+    FILTER (?value != "")
   }
   UNION {
-    SELECT (3 AS ?order) ("Editors" AS ?description) (GROUP_CONCAT(?value_; SEPARATOR=", ") AS ?value) (CONCAT("../authors/", GROUP_CONCAT(?q; SEPARATOR=",")) AS ?valueUrl) {
-      BIND (1 AS ?dummy)
-      target: wdt:P98 ?iri .
-      BIND (SUBSTR(STR(?iri),32) AS ?q)
-      ?iri rdfs:label ?value_string .
-      FILTER (LANG(?value_string) = 'en')
-      BIND (COALESCE(?value_string, ?q) AS ?value_)
+    {
+      SELECT (3 AS ?order) ("Editors" AS ?description) (GROUP_CONCAT(?_value; SEPARATOR=", ") AS ?value) (CONCAT("../authors/", GROUP_CONCAT(?qid; SEPARATOR=",")) AS ?valueUrl) {
+        target: wdt:P98 ?editor .
+        {{ sparql_helpers.labels(["?editor"], languages) }}
+        BIND (SUBSTR(STR(?editor), 32) AS ?qid)
+        BIND (COALESCE(?editorLabel, ?qid) AS ?_value)
+      }
     }
-    GROUP BY ?dummy
+    FILTER (?value != "")
   }
   UNION {
     BIND (2.5 AS ?order)
     BIND ("Language" AS ?description)
-    ?work wdt:P407 ?iri .
-    BIND (SUBSTR(STR(?iri),32) AS ?q)
-    ?iri rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (STR(?value_string) AS ?value)
-    BIND (CONCAT("../language/", ?q) AS ?valueUrl)
+    target: wdt:P407 ?_value .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../language/", ?qid) AS ?valueUrl)
   }
   UNION {
-    SELECT (3 AS ?order) ("Reviewers" AS ?description) (GROUP_CONCAT(?value_; SEPARATOR=", ") AS ?value) (CONCAT("../authors/", GROUP_CONCAT(?q; SEPARATOR=",")) AS ?valueUrl) {
-      BIND (1 AS ?dummy)
-      target: wdt:P4032 ?iri .
-      BIND (SUBSTR(STR(?iri),32) AS ?q)
-      ?iri rdfs:label ?value_string .
-      FILTER (LANG(?value_string) = 'en')
-      BIND (COALESCE(?value_string, ?q) AS ?value_)
+    {
+      SELECT (3 AS ?order) ("Reviewers" AS ?description) (GROUP_CONCAT(?_value; SEPARATOR=", ") AS ?value) (CONCAT("../authors/", GROUP_CONCAT(?qid; SEPARATOR=",")) AS ?valueUrl) {
+        target: wdt:P4032 ?reviewer .
+        {{ sparql_helpers.labels(["?reviewer"], languages) }}
+        BIND (SUBSTR(STR(?reviewer), 32) AS ?qid)
+        BIND (COALESCE(?reviewerLabel, ?qid) AS ?_value)
+      }
     }
-    GROUP BY ?dummy
+    FILTER (?value != "")
   }
   UNION {
     BIND (4 AS ?order)
     BIND ("Published in" AS ?description)
-    ?work wdt:P1433 ?iri .
-    BIND (SUBSTR(STR(?iri),32) AS ?q)
-    ?iri rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (COALESCE(?value_string, ?q) AS ?value)
-    BIND (CONCAT("../venue/", ?q) AS ?valueUrl)
+    target: wdt:P1433 ?_value .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../venue/", ?qid) AS ?valueUrl)
   }
   UNION {
     BIND (4 AS ?order)
     BIND ("Series" AS ?description)
-    ?work wdt:P179 ?iri .
-    BIND (SUBSTR(STR(?iri),32) AS ?q)
-    ?iri rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (COALESCE(?value_string, ?q) AS ?value)
-    BIND (CONCAT("../series/", ?q) AS ?valueUrl)
+    target: wdt:P179 ?_value .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../series/", ?qid) AS ?valueUrl)
   }
   UNION {
     BIND (6 AS ?order)
     BIND ("Publication date" AS ?description)
-    ?work p:P577/psv:P577 ?publication_date_value .
-    ?publication_date_value wikibase:timePrecision ?time_precision ;
-                            wikibase:timeValue ?publication_date .
-    BIND (IF(?time_precision = 9,YEAR(?publication_date),xsd:date(?publication_date)) AS ?value)
+    target: p:P577/psv:P577 [
+      wikibase:timePrecision ?time_precision ;
+      wikibase:timeValue ?publication_date
+    ]
+    BIND (IF(?time_precision = 9, YEAR(?publication_date), xsd:date(?publication_date)) AS ?value)
   }
   UNION {
     BIND (7 AS ?order)
     BIND ("Publisher" AS ?description)
-    ?work wdt:P123 ?iri .
-    BIND (SUBSTR(STR(?iri),32) AS ?q)
-    ?iri rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (COALESCE(?value_string, ?q) AS ?value)
-    BIND (CONCAT("../publisher/", ?q) AS ?valueUrl)
+    target: wdt:P123 ?_value .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../publisher/", ?qid) AS ?valueUrl)
   }
   UNION {
-    SELECT (8 AS ?order) ("Topics" AS ?description) (GROUP_CONCAT(?value_; SEPARATOR=", ") AS ?value) (CONCAT("../topics/", GROUP_CONCAT(?q; SEPARATOR=",")) AS ?valueUrl) {
-      BIND (1 AS ?dummy)
-      target: wdt:P921 ?iri .
-      BIND (SUBSTR(STR(?iri),32) AS ?q)
-      ?iri rdfs:label ?value_string .
-      FILTER (LANG(?value_string) = 'en')
-      BIND (COALESCE(?value_string, ?q) AS ?value_)
+    {
+      SELECT (8 AS ?order) ("Topics" AS ?description) (GROUP_CONCAT(?_value; SEPARATOR=", ") AS ?value) (CONCAT("../topics/", GROUP_CONCAT(?qid; SEPARATOR=",")) AS ?valueUrl) {
+        target: wdt:P921 ?topic .
+        {{ sparql_helpers.labels(["?topic"], languages) }}
+        BIND (SUBSTR(STR(?topic), 32) AS ?qid)
+        BIND (COALESCE(?topicLabel, ?qid) AS ?_value)
+      }
     }
-    GROUP BY ?dummy
+    FILTER (?value != "")
   }
   UNION {
-    SELECT (9 AS ?order) ("Uses" AS ?description) (GROUP_CONCAT(?value_; SEPARATOR=", ") AS ?value) (CONCAT("../uses/", GROUP_CONCAT(?q; SEPARATOR=",")) AS ?valueUrl) {
-      BIND (1 AS ?dummy)
-      target: wdt:P4510 ?iri .
-      BIND (SUBSTR(STR(?iri),32) AS ?q)
-      ?iri rdfs:label ?value_string .
-      FILTER (LANG(?value_string) = 'en')
-      BIND (COALESCE(?value_string, ?q) AS ?value_)
+    {
+      SELECT (9 AS ?order) ("Uses" AS ?description) (GROUP_CONCAT(?_value; SEPARATOR=", ") AS ?value) (CONCAT("../uses/", GROUP_CONCAT(?qid; SEPARATOR=",")) AS ?valueUrl) {
+        target: wdt:P4510 ?use .
+        {{ sparql_helpers.labels(["?use"], languages) }}
+        BIND (SUBSTR(STR(?use), 32) AS ?qid)
+        BIND (COALESCE(?useLabel, ?qid) AS ?_value)
+      }
     }
-    GROUP BY ?dummy
+    FILTER (?value != "")
   }
   UNION {
     BIND (10 AS ?order)
     BIND ("DOI" AS ?description)
-    ?work wdt:P356 ?valueUrl_ .
+    target: wdt:P356 ?valueUrl_ .
     BIND (CONCAT("https://doi.org/", ENCODE_FOR_URI(?valueUrl_)) AS ?valueUrl)
     BIND (CONCAT(?valueUrl_, " ↗") AS ?value)
   }
   UNION {
     BIND (11 AS ?order)
     BIND ("Homepage" AS ?description)
-    ?work wdt:P856 ?valueUrl .
-    BIND (STR(?valueUrl) AS ?value)
+    target: wdt:P856 ?valueUrl .
+    BIND (CONCAT(STR(?valueUrl), " ↗") AS ?value)
   }
   UNION {
     BIND (12 AS ?order)
     BIND ("Full text" AS ?description)
-    ?work wdt:P953 ?valueUrl .
+    target: wdt:P953 ?valueUrl .
     BIND (CONCAT(STR(?valueUrl), " ↗") AS ?value)
   }
   UNION {
     BIND (13 AS ?order)
     BIND ("🛑 Retracted" AS ?description)
     {
-      ?work wdt:P31 wd:Q45182324 .
-    }
-    UNION {
-      ?work wdt:P793 wd:Q7316896 .
+      target: wdt:P31 wd:Q45182324 .
+    } UNION {
+      target: wdt:P793 wd:Q7316896 .
     }
     BIND ("open as retraction" AS ?value)
-    BIND (SUBSTR(STR(?work),32) AS ?q)
-    BIND (CONCAT("../retraction/", ?q) AS ?valueUrl)
+    BIND ("../retraction/{{ q }}" AS ?valueUrl)
   }
   UNION {
     BIND (14 AS ?order)
     BIND ("🛑 Retracted by" AS ?description)
-    ?work wdt:P5824 ?iri .
-    BIND (SUBSTR(STR(?iri),32) AS ?q)
-    ?iri rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (COALESCE(?value_string, ?q) AS ?value)
-    BIND (CONCAT("../work/", ?q) AS ?valueUrl)
+    target: wdt:P5824 ?_value .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../work/", ?qid) AS ?valueUrl)
   }
   UNION {
     BIND (15 AS ?order)
     BIND ("⚠️ Preprint" AS ?description)
-    {
-      ?work p:P31 ?statement .
-      ?statement ps:P31 wd:Q580922 .
-      MINUS {
-        ?statement pq:P642 []
-      }
+    target: p:P31 ?statement .
+    ?statement ps:P31 wd:Q580922 .
+    MINUS {
+      ?statement pq:P642 []
     }
   }
   UNION {
     SELECT (COUNT(DISTINCT ?citationStatement) AS ?value) ?order ?description ?valueUrl WHERE {
-      #      VALUES ?work { wd:{{ q }} }
       VALUES ?intention { wd:Q96472102 wd:Q101149476 wd:Q96471820 }
-      ?work ^ps:P2860 ?citationStatement .
+      target: ^ps:P2860 ?citationStatement .
       ?citationStatement pq:P3712 ?intention .
-      BIND (20 AS ?order)
-      BIND ("Data or method used by" AS ?description)
-      #      BIND("./{{ q }}/cito" AS ?valueUrl)
-    }
-    GROUP BY ?order ?description ?valueUrl
+      BIND(20 AS ?order)
+      BIND("Data or method used by" AS ?description)
+      BIND("./{{ q }}/cito" AS ?valueUrl)
+    } GROUP BY ?order ?description ?valueUrl
   }
   UNION {
     SELECT (COUNT(DISTINCT ?citationStatement) AS ?value) ?order ?description ?valueUrl WHERE {
-      #      VALUES ?work { wd:{{ q }} }
       VALUES ?intention { wd:Q107687829 wd:Q107710355 wd:Q117121923 wd:Q117121932 }
-      ?work ^ps:P2860 ?citationStatement .
+      target: ^ps:P2860 ?citationStatement .
       ?citationStatement pq:P3712 ?intention .
-      BIND (21 AS ?order)
-      BIND ("Disagreed with by" AS ?description)
-      #      BIND("./{{ q }}/cito" AS ?valueUrl)
-    }
-    GROUP BY ?order ?description ?valueUrl
+      BIND(21 AS ?order)
+      BIND("Disagreed with by" AS ?description)
+      BIND("./{{ q }}/cito" AS ?valueUrl)
+    } GROUP BY ?order ?description ?valueUrl
   }
   UNION {
     BIND (30 AS ?order)
     BIND ("⚠️ Preprint of" AS ?description)
-    {
-      ?work p:P31 ?statement .
-      ?statement pq:P642 ?pub ;
-                 ps:P31 wd:Q580922 .
-      BIND (SUBSTR(STR(?pub),32) AS ?pubqid)
-      ?pub rdfs:label ?value_string .
-      FILTER (LANG(?value_string) = 'en')
-      BIND (COALESCE(?value_string, ?pubqid) AS ?value)
-      BIND (CONCAT("../work/", ?pubqid) AS ?valueUrl)
-    }
+    target: p:P31 ?statement .
+    ?statement pq:P642 ?_value ;
+               ps:P31 wd:Q580922 .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../work/", ?qid) AS ?valueUrl)
   }
   UNION {
     BIND (31 AS ?order)
     BIND ("⚠️ Cites retracted article" AS ?description)
     {
-      ?work wdt:P2860 ?retracted .
-      ?retracted wdt:P31 wd:Q45182324 .
+      target: wdt:P2860 ?_value .
+      ?_value wdt:P31 wd:Q45182324 .
+    } UNION {
+      target: wdt:P2860 ?_value .
+      ?_value wdt:P793 wd:Q7316896 .
+    } UNION {
+      target: wdt:P2860 ?_value .
+      ?_value wdt:P5824 [] .
     }
-    UNION {
-      ?work wdt:P2860 ?retracted .
-      ?retracted wdt:P793 wd:Q7316896 .
-    }
-    UNION {
-      ?work wdt:P2860 ?retracted .
-      ?retracted wdt:P5824 [] .
-    }
-    ?retracted rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (SUBSTR(STR(?retracted),32) AS ?q)
-    BIND (COALESCE(?value_string, ?q) AS ?value)
-    BIND (CONCAT("../work/", ?q) AS ?valueUrl)
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../work/", ?qid) AS ?valueUrl)
   }
   UNION {
     BIND (32 AS ?order)
     BIND ("Preprint" AS ?description)
-    {
-      ?preprint p:P31 ?statement .
-      ?statement pq:P642 ?work ;
-                 ps:P31 wd:Q580922 .
-      BIND (SUBSTR(STR(?preprint),32) AS ?pubqid)
-      ?preprint rdfs:label ?value_string .
-      FILTER (LANG(?value_string) = 'en')
-      BIND (COALESCE(?value_string, ?pubqid) AS ?value)
-      BIND (CONCAT("../work/", ?pubqid) AS ?valueUrl)
-    }
+    ?_value p:P31 ?statement .
+    ?statement pq:P642 target: ;
+                ps:P31 wd:Q580922 .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../", ?qid) AS ?valueUrl)
   }
   UNION {
     BIND (33 AS ?order)
     BIND ("⚠️ Erratum of" AS ?description)
-    {
-      ?work p:P31 ?statement .
-      ?statement pq:P642 ?pub ;
-                 ps:P31 wd:Q1348305 .
-      BIND (SUBSTR(STR(?pub),32) AS ?pubqid)
-      ?pub rdfs:label ?value_string .
-      FILTER (LANG(?value_string) = 'en')
-      BIND (COALESCE(?value_string, ?pubqid) AS ?value)
-      BIND (CONCAT("../work/", ?pubqid) AS ?valueUrl)
-    }
+    target: p:P31 ?statement .
+    ?statement pq:P642 ?_value ;
+                ps:P31 wd:Q1348305 .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../", ?qid) AS ?valueUrl)
   }
   UNION {
     BIND (34 AS ?order)
     BIND ("⚠️ Retracts" AS ?description)
     {
-      {
-        ?work p:P31 ?statement .
-        ?statement pq:P642 ?pub ;
-                   ps:P31 wd:Q7316896 .
-      }
-      UNION {
-        ?work ^wdt:P5824 ?pub .
-      }
-      BIND (SUBSTR(STR(?pub),32) AS ?pubqid)
-      ?pub rdfs:label ?value_string .
-      FILTER (LANG(?value_string) = 'en')
-      BIND (COALESCE(?value_string, ?pubqid) AS ?value)
-      BIND (CONCAT("../work/", ?pubqid) AS ?valueUrl)
+      target: p:P31 ?statement .
+      ?statement pq:P642 ?_value ;
+                 ps:P31 wd:Q7316896 .
+    } UNION {
+      target: ^wdt:P5824 ?_value .
     }
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../", ?qid) AS ?valueUrl)
   }
   UNION {
     BIND (35 AS ?order)
     BIND ("Replies to" AS ?description)
-    ?work wdt:P2675 ?value_ .
-    BIND (SUBSTR(STR(?value_),32) AS ?valueqid)
-    ?value_ rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (COALESCE(?value_string, ?valueqid) AS ?value)
-    BIND (CONCAT("../", ?valueqid) AS ?valueUrl)
+    target: wdt:P2675 ?_value .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../", ?qid) AS ?valueUrl)
   }
   UNION {
     BIND (36 AS ?order)
     BIND ("Inspired by" AS ?description)
-    ?work wdt:P941 ?value_ .
-    BIND (SUBSTR(STR(?value_),32) AS ?valueqid)
-    ?value_ rdfs:label ?value_string .
-    FILTER (LANG(?value_string) = 'en')
-    BIND (COALESCE(?value_string, ?valueqid) AS ?value)
-    BIND (CONCAT("../", ?valueqid) AS ?valueUrl)
+    target: wdt:P941 ?_value .
+    {{ sparql_helpers.labels(["?_value"], languages) }}
+    BIND (SUBSTR(STR(?_value), 32) AS ?qid)
+    BIND (COALESCE(?_valueLabel, ?qid) AS ?value)
+    BIND (CONCAT("../", ?qid) AS ?valueUrl)
   }
 }
 ORDER BY ?order

--- a/scholia/app/templates/work_list-of-authors.sparql
+++ b/scholia/app/templates/work_list-of-authors.sparql
@@ -1,53 +1,47 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
+#title: List of authors for a work
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-# List of authors for a work
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 PREFIX ps: <http://www.wikidata.org/prop/statement/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-PREFIX schema: <http://schema.org/>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 SELECT DISTINCT
-# Author order
-?order ?academic_age
-# Author item and label
-?author ?authorUrl ?authorDescription WHERE {
+  # Author order
+  ?order ?academic_age
+  # Author item and label
+  ?author ?authorUrl ?authorDescription
+WHERE {
   {
-    target: p:P50 ?author_statement .
-    ?author_statement ps:P50 ?author_ .
-    ?author_ rdfs:label ?author .
-    FILTER (LANG(?author) = 'en')
-    BIND (CONCAT("../author/", SUBSTR(STR(?author_),32)) AS ?authorUrl)
+    target: p:P50 ?statement .
+    ?statement ps:P50 ?_author .
+
+    {{ sparql_helpers.labels(["?_author"], languages) }}
+    {{ sparql_helpers.descriptions(["?_author"], languages) }}
+    BIND (?_authorLabel AS ?author)
+    BIND (?_authorDescription AS ?authorDescription)
+    BIND (CONCAT("../author/", SUBSTR(STR(?_author), 32)) AS ?authorUrl)
+
     OPTIONAL {
-      ?author_statement pq:P1545 ?order_ .
-      BIND (xsd:integer(?order_) AS ?order)
+      SELECT ?_author (MAX(?academic_age_) AS ?academic_age) {
+        target: wdt:P50 ?_author ;
+                wdt:P577 ?publication_date .
+        [] wdt:P31/wdt:P279* wd:Q55915575 ;
+          wdt:P50 ?_author ;
+          wdt:P577 ?other_publication_date .
+        BIND (YEAR(?publication_date) - YEAR(?other_publication_date) AS ?academic_age_)
+      } GROUP BY ?_author
     }
-    OPTIONAL {
-      ?author_ schema:description ?authorDescription .
-      FILTER (LANG(?authorDescription) = "en")
-    }
+  } UNION {
+    target: p:P2093 ?statement .
+    ?statement ps:P2093 ?_author
+    BIND (CONCAT(?_author, " ↗") AS ?author)
+    BIND (CONCAT("https://author-disambiguator.toolforge.org/names_oauth.php?doit=Look+for+author&name=", ENCODE_FOR_URI(?_author)) AS ?authorUrl)
   }
-  UNION {
-    target: p:P2093 ?authorstring_statement .
-    ?authorstring_statement ps:P2093 ?author_
-    BIND (CONCAT(?author_, " ↗") AS ?author)
-    OPTIONAL {
-      ?authorstring_statement pq:P1545 ?order_ .
-      BIND (xsd:integer(?order_) AS ?order)
-    }
-    BIND (CONCAT("https://author-disambiguator.toolforge.org/names_oauth.php?doit=Look+for+author&name=", ENCODE_FOR_URI(?author_)) AS ?authorUrl)
-  }
-  OPTIONAL {
-    SELECT ?author_ (MAX(?academic_age_) AS ?academic_age) {
-      target: wdt:P50 ?author_ ;
-              wdt:P577 ?publication_date .
-      [] wdt:P31/wdt:P279* wd:Q55915575 ;
-         wdt:P50 ?author_ ;
-         wdt:P577 ?other_publication_date .
-      BIND (YEAR(?publication_date) - YEAR(?other_publication_date) AS ?academic_age_)
-    }
-    GROUP BY ?author_
-  }
+
+  OPTIONAL { ?statement pq:P1545 ?order_ . }
+  BIND (xsd:integer(?order_) AS ?order)
 }
 ORDER BY ?order

--- a/scholia/app/templates/work_related-works.sparql
+++ b/scholia/app/templates/work_related-works.sparql
@@ -1,19 +1,25 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
+#title: List of related works by co-citation analysis
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-# List of related works by co-citation analysis
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?count ?work (REPLACE(STR(?work), ".*/", "") AS ?workLabel) WHERE {
+SELECT ?count ?work ?workLabel WHERE {
   {
     SELECT ?work (COUNT(?work) AS ?count) WHERE {
-      target: (^wdt:P2860 | wdt:P2860)/(^wdt:P2860 | wdt:P2860)? ?work .
+      { target: ^wdt:P2860/^wdt:P2860 ?work }
+      UNION
+      { target: wdt:P2860/^wdt:P2860 ?work }
+      UNION
+      { target: ^wdt:P2860/wdt:P2860 ?work }
+      UNION
+      { target: wdt:P2860/wdt:P2860 ?work }
       FILTER (target: != ?work)
     }
     GROUP BY ?work
     ORDER BY DESC(?count)
     LIMIT 500
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
+  {{ sparql_helpers.labels(["?work"], languages) }}
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/work_statements.sparql
+++ b/scholia/app/templates/work_statements.sparql
@@ -1,38 +1,38 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #title: Statements referencing the {{ q }} article
 #defaultView:Table
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX pr: <http://www.wikidata.org/prop/reference/>
 PREFIX prov: <http://www.w3.org/ns/prov#>
 PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?item (REPLACE(STR(?item), ".*/", "") AS ?itemLabel) ?property (REPLACE(STR(?property), ".*/", "") AS ?propertyLabel) ?value (REPLACE(STR(?value), ".*/", "") AS ?valueLabel) ?unit (REPLACE(STR(?unit), ".*/", "") AS ?unitLabel) WHERE {
+SELECT ?item ?itemLabel ?property ?propertyLabel ?value ?valueLabel ?unit ?unitLabel WHERE {
   {
-    SELECT DISTINCT ?item ?property ?value ?unit WHERE {
-      {
-        SELECT ?statement WHERE {
-          ?statement prov:wasDerivedFrom/pr:P248 target: .
-        }
-        LIMIT 2000
-      }
-      ?item ?p ?statement .
-      ?property wikibase:claim ?p .
-      OPTIONAL {
-        ?property wikibase:statementValueNormalized ?a1
-      }
-      ?statement ?a1 ?value1 ;
-                 ?a2 ?value2 .
-      BIND (COALESCE(?value1, ?value2) AS ?value)
-      BIND (COALESCE(?a1, ?a2) AS ?a)
-      FILTER (!STRSTARTS(LCASE(STR(?value)),"http://wikiba.se/ontology#"))
-      FILTER (!STRSTARTS(LCASE(STR(?value)),"http://www.wikidata.org/value/"))
-      FILTER (!STRSTARTS(LCASE(STR(?value)),"http://www.wikidata.org/reference/"))
-      OPTIONAL {
-        ?statement ?psv_statement_predicate ?psv_statement .
-        ?statement_predicate_property wikibase:statementValue ?psv_statement_predicate .
-        ?psv_statement wikibase:quantityUnit ?unit
-      }
+    { SELECT ?statement WHERE { ?statement prov:wasDerivedFrom/pr:P248 target: . } }
+    ?item a wikibase:Item ; ?p ?statement .
+    ?property wikibase:claim ?p ; wikibase:statementProperty ?ps .
+    ?statement ?ps ?value .
+    FILTER NOT EXISTS {
+      ?property wikibase:statementValueNormalized ?pn .
+      FILTER (ISLITERAL(?value))
     }
+  } UNION {
+    { SELECT ?statement WHERE { ?statement prov:wasDerivedFrom/pr:P248 target: . } }
+    ?item a wikibase:Item ; ?p ?statement .
+    ?property wikibase:claim ?p ; wikibase:statementValueNormalized ?pn .
+    ?statement ?pn ?value .
+    FILTER (ISLITERAL(?value))
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . } 
+
+  OPTIONAL {
+    { SELECT ?statement WHERE { ?statement prov:wasDerivedFrom/pr:P248 target: . } }
+    ?item a wikibase:Item ; ?p ?statement .
+    ?property wikibase:claim ?p ; wikibase:statementProperty ?ps ; wikibase:statementValue ?psv .
+    ?statement ?psv [ wikibase:quantityUnit ?unit ]
+    {{ sparql_helpers.labels(["?unit"], languages) }}
+  }
+
+  {{ sparql_helpers.labels(["?item", "?property", "?value"], languages) }}
 }
-ORDER BY DESC(?itemLabel)
+ORDER BY ?item ?property
+LIMIT 2000

--- a/scholia/app/templates/work_timeline.sparql
+++ b/scholia/app/templates/work_timeline.sparql
@@ -1,9 +1,10 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:Timeline
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX p: <http://www.wikidata.org/prop/>
 PREFIX pq: <http://www.wikidata.org/prop/qualifier/>
 PREFIX ps: <http://www.wikidata.org/prop/statement/>
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 SELECT DISTINCT ?datetime ?description WHERE {
@@ -22,11 +23,11 @@ SELECT DISTINCT ?datetime ?description WHERE {
   UNION {
     target: p:P793 ?event_statement .
     ?event_statement ps:P793 ?event_type .
-    ?event_type rdfs:label ?description_ .
     ?event_statement pq:P585 ?datetime .
-    FILTER (LANG(?description_) = "en")
+    {{ sparql_helpers.labels(["?event_type"], languages) }}
+
     # Warning icon for retraction
-    BIND (IF(?event_type = wd:Q45203135,CONCAT("⛔ ", ?description_),IF(?event_type = wd:Q56478588,CONCAT("❓ ", ?description_),?description_)) AS ?description)
+    BIND (IF(?event_type = wd:Q45203135,CONCAT("⛔ ", ?event_typeLabel),IF(?event_type = wd:Q56478588,CONCAT("❓ ", ?event_typeLabel),?event_typeLabel)) AS ?description)
   }
   UNION {
     SELECT ?datetime ?description WHERE {

--- a/scholia/app/templates/work_topic-scores.sparql
+++ b/scholia/app/templates/work_topic-scores.sparql
@@ -1,9 +1,9 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:BubbleChart
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
-PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?score ?topic (REPLACE(STR(?topic), ".*/", "") AS ?topicLabel) WHERE {
+SELECT ?score ?topic ?topicLabel WHERE {
   {
     SELECT (SUM(?score_) AS ?score) ?topic WHERE {
       {
@@ -28,7 +28,7 @@ SELECT ?score ?topic (REPLACE(STR(?topic), ".*/", "") AS ?topicLabel) WHERE {
     }
     GROUP BY ?topic
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en,da,de,es,jp,no,ru,sv,zh". }
+  {{ sparql_helpers.labels(["?topic"], languages) }}
 }
 ORDER BY DESC(?score)
 LIMIT 200

--- a/scholia/app/templates/work_wikipedia-mentions.sparql
+++ b/scholia/app/templates/work_wikipedia-mentions.sparql
@@ -1,3 +1,5 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
@@ -77,7 +79,8 @@ SELECT ?title ?titleUrl ?wikipedia ?wikipediaLabel ?item ?itemLabel ?itemDescrip
       BIND (wd:Q11921 AS ?wikipedia)
     }
   }
-  # hint:Prior hint:runFirst "true" .
   BIND (CONCAT(?title_, "&nbsp;↗") AS ?title)
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+
+  {{ sparql_helpers.labels(["?wikipedia", "?item"], languages) }}
+  {{ sparql_helpers.descriptions(["?item"], languages) }}
 }

--- a/scholia/app/templates/works_authors.sparql
+++ b/scholia/app/templates/works_authors.sparql
@@ -1,16 +1,17 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?count ?author ?authorLabel ?example_work ?example_workLabel WHERE {
   {
     SELECT (COUNT(?work) AS ?count) ?author (SAMPLE(?work) AS ?example_work) WHERE {
-      VALUES ?work { {% for q in qs %} wd:{{ q }} {% endfor %} }
+      VALUES ?work { {% for q in qs -%} wd:{{ q }} {% endfor -%} }
       ?work wdt:P50 ?author .
     }
     GROUP BY ?author
     ORDER BY DESC(?count)
     LIMIT 200
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+  {{ sparql_helpers.labels(["?author", "?example_work"], languages) }}
 }
 ORDER BY DESC(?count)

--- a/scholia/app/templates/works_citations-per-year.sparql
+++ b/scholia/app/templates/works_citations-per-year.sparql
@@ -1,22 +1,14 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:LineChart
-PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-SELECT ?year ?number_of_citations ?work WHERE {
-  {
-    SELECT ?year ?number_of_citations ?work1 (SAMPLE(?work1Labels) AS ?work1Label) WHERE {
-      {
-        SELECT ?year (COUNT(DISTINCT ?citing_work) AS ?number_of_citations) ?work1 WHERE {
-          #    VALUES ?work1 {   {% for q in qs %} wd:{{ q }} {% endfor %}   }
-          ?citing_work wdt:P2860 ?work1 .
-          # Year of citation 
-          ?citing_work wdt:P577 ?date .
-          BIND (STR(YEAR(?date)) AS ?year)
-        }
-        GROUP BY ?year ?work1
-      }
-      ?work1 rdfs:label ?work1Labels .
-    }
-    GROUP BY ?year ?number_of_citations ?work1
-  }
-  BIND (CONCAT(?work1Label, " (", SUBSTR(STR(?work1),32), ")") AS ?work)
+SELECT ?year (COUNT(DISTINCT ?citing_work) AS ?number_of_citations) (CONCAT(?work1Label, " (", SUBSTR(STR(?work1), 32), ")") AS ?work) WHERE {
+  VALUES ?work1 { {% for q in qs -%} wd:{{ q }} {% endfor -%} }
+  ?citing_work wdt:P2860 ?work1 .
+  # Year of citation
+  ?citing_work wdt:P577 ?date .
+  BIND (STR(YEAR(?date)) AS ?year)
+  {{ sparql_helpers.labels(["?work1"], languages) }}
 }
+GROUP BY ?year ?work1 ?work1Label

--- a/scholia/app/templates/works_citing-works.sparql
+++ b/scholia/app/templates/works_citing-works.sparql
@@ -1,11 +1,12 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
 SELECT ?count (MIN(?dates) AS ?date) ?citing_work ?citing_workLabel WHERE {
   {
     SELECT (COUNT(?work) AS ?count) ?citing_work WHERE {
-      VALUES ?work { {% for q in qs %} wd:{{ q }} {% endfor %} }
+      VALUES ?work { {% for q in qs -%} wd:{{ q }} {% endfor -%} }
       ?citing_work wdt:P2860 ?work .
     }
     GROUP BY ?citing_work
@@ -16,7 +17,7 @@ SELECT ?count (MIN(?dates) AS ?date) ?citing_work ?citing_workLabel WHERE {
     ?citing_work wdt:P577 ?datetimes .
     BIND (xsd:date(?datetimes) AS ?dates)
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+  {{ sparql_helpers.labels(["?citing_work"], languages) }}
 }
 GROUP BY ?count ?citing_work ?citing_workLabel
 ORDER BY DESC(?count) DESC(?date)

--- a/scholia/app/templates/works_list-of-works.sparql
+++ b/scholia/app/templates/works_list-of-works.sparql
@@ -1,15 +1,20 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?work (REPLACE(STR(?work), ".*/", "") AS ?workLabel) ?example_author (REPLACE(STR(?example_author), ".*/", "") AS ?example_authorLabel) WHERE {
+SELECT ?work ?workLabel ?example_author ?example_authorLabel WHERE {
   {
-    SELECT ?work (SAMPLE(?author) AS ?example_author) WHERE {
-      VALUES ?work { {% for q in qs %} wd:{{ q }} {% endfor %} }
-      OPTIONAL {
+    VALUES ?work { {% for q in qs -%} wd:{{ q }} {% endfor -%} }
+    FILTER NOT EXISTS { ?work wdt:P50 [] }
+  }
+  UNION {
+    {
+      SELECT ?work (SAMPLE(?author) AS ?example_author) WHERE {
+        VALUES ?work { {% for q in qs -%} wd:{{ q }} {% endfor -%} }
         ?work wdt:P50 ?author
       }
+      GROUP BY ?work
     }
-    GROUP BY ?work
+    {{ sparql_helpers.labels(["?work", "?example_author"], languages) }}
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
 }

--- a/scholia/app/templates/works_topics.sparql
+++ b/scholia/app/templates/works_topics.sparql
@@ -1,17 +1,13 @@
-PREFIX wd: <http://www.wikidata.org/entity/>
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
+
 #defaultView:BubbleChart
+PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
-PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?count ?topic ?topicLabel WHERE {
-  {
-    SELECT (COUNT(?work) AS ?count) ?topic WHERE {
-      VALUES ?work {  {% for q in qs %} wd:{{ q }} {% endfor %}  }
-      ?work wdt:P921 ?topic .
-    }
-    GROUP BY ?topic
-    ORDER BY ?count
-    LIMIT 200
-  }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+SELECT (COUNT(?work) AS ?count) ?topic ?topicLabel WHERE {
+  VALUES ?work { {% for q in qs -%} wd:{{ q }} {% endfor -%} }
+  ?work wdt:P921 ?topic .
+  {{ sparql_helpers.labels(["?topic"], languages) }}
 }
+GROUP BY ?topic ?topicLabel
 ORDER BY DESC(?count)
+LIMIT 200


### PR DESCRIPTION
### Description
Uses the sparql macros from #20 to update the queries for the work aspects. Exception is temporarily disabling `work_wikipedia-mentions.sparql` which uses `SERVICE wikibase:mwapi` (see #5).

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
