### PR TITLE
Federate with WDQS for specific non-standard features (`wikibase:mwapi`)

### DIFF
--- a/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
+++ b/scholia/app/templates/taxon-curation_missing-topic-tags-for-taxon-name.sparql
@@ -1,32 +1,32 @@
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
+PREFIX mwapi: <https://www.mediawiki.org/ontology#API/>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT DISTINCT ?item ?itemLabel (CONCAT("/work/", SUBSTR(STR(?item),32)) AS ?itemUrl) ?taxonname (REPLACE(STR(?item), ".*Q", "Q") AS ?work) ("P921" AS ?main_subject) (REPLACE(STR(target:), ".*Q", "Q") AS ?taxon) ("S887" AS ?heuristic) ("Q69652283" AS ?deduced) WHERE {
-  {
-    SELECT ?item ?taxonname WHERE {
-      target: wdt:P225 ?taxonname .
-      target: wdt:P105 wd:Q7432 . # this filters for species-level (Q7432) taxon names; comment out or adapt as necessary
-      SERVICE wikibase:mwapi {
-        bd:serviceParam wikibase:endpoint "www.wikidata.org" ;
-                        wikibase:api "Generator" ;
-                        mwapi:generator "search" ;
-                        mwapi:gsrsearch ?taxonname ;
-                        mwapi:gsrlimit "max" .
-        ?item wikibase:apiOutputItem mwapi:title.
-      }
-      ?item wdt:P1476 ?title .
-      MINUS {
-        ?item wdt:P921 target:
-      }
-      MINUS {
-        ?item wdt:P921 [ wdt:P171* target: ]
-      } # this filters out works about subspecies of the target
-      FILTER (REGEX(LCASE(?title),LCASE(CONCAT("\\", "b", ?taxonname, "\\", "b"))))
+
+SELECT DISTINCT ?item (?title AS ?itemLabel) (CONCAT("/work/", ?work) AS ?itemUrl) ?taxonname ?work ("P921" AS ?main_subject) ?taxon ("S887" AS ?heuristic) ("Q69652283" AS ?deduced) WHERE {
+  SERVICE <https://query.wikidata.org/sparql> {
+    # this filters for species-level (Q7432) taxon names; comment out or adapt as necessary
+    target: wdt:P105 wd:Q7432 .
+    target: wdt:P225 ?taxonname .
+
+    SERVICE wikibase:mwapi {
+      bd:serviceParam wikibase:endpoint "www.wikidata.org" ;
+                      wikibase:api "Generator" ;
+                      mwapi:generator "search" ;
+                      mwapi:gsrsearch ?taxonname ;
+                      mwapi:gsrlimit "max" .
+      ?item wikibase:apiOutputItem mwapi:title .
     }
-    LIMIT 200
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
-}
-LIMIT 200
+
+  ?item wdt:P1476 ?title .
+  # this filters out works about subspecies of the target
+  MINUS { ?item wdt:P921/wdt:P171* target: }
+
+  FILTER (REGEX(?title, CONCAT("\\\\b", ?taxonname, "\\\\b"), "i"))
+
+  BIND (SUBSTR(STR(?item), 32) AS ?work)
+  BIND (SUBSTR(STR(target:), 32) AS ?taxon)
+} LIMIT 200

--- a/scholia/app/templates/work.html
+++ b/scholia/app/templates/work.html
@@ -10,7 +10,7 @@
 {{ sparql_to_table('citations') }}
 {{ sparql_to_table('cited-works') }}
 {{ sparql_to_table('cited-work-authors') }}
-{# {{ sparql_to_table('wikipedia-mentions') }} #}
+{{ sparql_to_table_post('wikipedia-mentions') }}
 {{ sparql_to_table('statements') }}
 
 {{ sparql_to_iframe('topic-scores') }}
@@ -133,9 +133,9 @@ Recent citations to the work
 </div>
 
 
-<!-- <h2 id="wikipedia-mentions">Wikipedia mentions</h2> -->
+<h2 id="wikipedia-mentions">Wikipedia mentions</h2>
 
-<!-- <table class="table table-hover" id="wikipedia-mentions-table"></table> -->
+<table class="table table-hover" id="wikipedia-mentions-table"></table>
 
 
 

--- a/scholia/app/templates/work_wikipedia-mentions.sparql
+++ b/scholia/app/templates/work_wikipedia-mentions.sparql
@@ -1,16 +1,17 @@
 {% import 'sparql-helpers.sparql' as sparql_helpers -%}
 
 PREFIX bd: <http://www.bigdata.com/rdf#>
+PREFIX mwapi: <https://www.mediawiki.org/ontology#API/>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT ?title ?titleUrl ?wikipedia ?wikipediaLabel ?item ?itemLabel ?itemDescription WHERE {
-  {
-    SELECT ?title_ ?titleUrl ?item ?wikipedia {
+  SERVICE <https://query.wikidata.org/sparql> {
+    {
       SERVICE wikibase:mwapi {
         bd:serviceParam wikibase:endpoint "da.wikipedia.org" ;
                         wikibase:api "Generator" ;
                         mwapi:generator "search" ;
-        #                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
                         mwapi:gsrlimit "200" .
         ?title_ wikibase:apiOutput mwapi:title .
         ?item wikibase:apiOutputItem mwapi:item .
@@ -18,14 +19,12 @@ SELECT ?title ?titleUrl ?wikipedia ?wikipediaLabel ?item ?itemLabel ?itemDescrip
       BIND (URI(CONCAT("https://da.wikipedia.org/wiki/", ENCODE_FOR_URI(REPLACE(?title_, " ", "_")))) AS ?titleUrl)
       BIND (wd:Q181163 AS ?wikipedia)
     }
-  }
-  UNION {
-    SELECT ?title_ ?titleUrl ?item ?wikipedia {
+    UNION {
       SERVICE wikibase:mwapi {
         bd:serviceParam wikibase:endpoint "de.wikipedia.org" ;
                         wikibase:api "Generator" ;
                         mwapi:generator "search" ;
-        #                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
                         mwapi:gsrlimit "200" .
         ?title_ wikibase:apiOutput mwapi:title .
         ?item wikibase:apiOutputItem mwapi:item .
@@ -33,14 +32,12 @@ SELECT ?title ?titleUrl ?wikipedia ?wikipediaLabel ?item ?itemLabel ?itemDescrip
       BIND (URI(CONCAT("https://de.wikipedia.org/wiki/", ENCODE_FOR_URI(REPLACE(?title_, " ", "_")))) AS ?titleUrl)
       BIND (wd:Q48183 AS ?wikipedia)
     }
-  }
-  UNION {
-    SELECT ?title_ ?titleUrl ?item ?wikipedia {
+    UNION {
       SERVICE wikibase:mwapi {
         bd:serviceParam wikibase:endpoint "en.wikipedia.org" ;
                         wikibase:api "Generator" ;
                         mwapi:generator "search" ;
-        #                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
                         mwapi:gsrlimit "200" .
         ?title_ wikibase:apiOutput mwapi:title .
         ?item wikibase:apiOutputItem mwapi:item .
@@ -48,14 +45,12 @@ SELECT ?title ?titleUrl ?wikipedia ?wikipediaLabel ?item ?itemLabel ?itemDescrip
       BIND (URI(CONCAT("https://en.wikipedia.org/wiki/", ENCODE_FOR_URI(REPLACE(?title_, " ", "_")))) AS ?titleUrl)
       BIND (wd:Q328 AS ?wikipedia)
     }
-  }
-  UNION {
-    SELECT ?title_ ?titleUrl ?item ?wikipedia {
+    UNION {
       SERVICE wikibase:mwapi {
         bd:serviceParam wikibase:endpoint "fr.wikipedia.org" ;
                         wikibase:api "Generator" ;
                         mwapi:generator "search" ;
-        #                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
                         mwapi:gsrlimit "200" .
         ?title_ wikibase:apiOutput mwapi:title .
         ?item wikibase:apiOutputItem mwapi:item .
@@ -63,14 +58,12 @@ SELECT ?title ?titleUrl ?wikipedia ?wikipediaLabel ?item ?itemLabel ?itemDescrip
       BIND (URI(CONCAT("https://fr.wikipedia.org/wiki/", ENCODE_FOR_URI(REPLACE(?title_, " ", "_")))) AS ?titleUrl)
       BIND (wd:Q8447 AS ?wikipedia)
     }
-  }
-  UNION {
-    SELECT ?title_ ?titleUrl ?item ?wikipedia {
+    UNION {
       SERVICE wikibase:mwapi {
         bd:serviceParam wikibase:endpoint "pt.wikipedia.org" ;
                         wikibase:api "Generator" ;
                         mwapi:generator "search" ;
-        #                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
+                        mwapi:gsrsearch '{{ q }}{% for doi in dois %} OR "{{ doi }}"{% endfor %}' ;
                         mwapi:gsrlimit "200" .
         ?title_ wikibase:apiOutput mwapi:title .
         ?item wikibase:apiOutputItem mwapi:item .
@@ -79,8 +72,8 @@ SELECT ?title ?titleUrl ?wikipedia ?wikipediaLabel ?item ?itemLabel ?itemDescrip
       BIND (wd:Q11921 AS ?wikipedia)
     }
   }
-  BIND (CONCAT(?title_, "&nbsp;↗") AS ?title)
 
+  BIND (CONCAT(?title_, "&nbsp;↗") AS ?title)
   {{ sparql_helpers.labels(["?wikipedia", "?item"], languages) }}
   {{ sparql_helpers.descriptions(["?item"], languages) }}
 }


### PR DESCRIPTION
Fixes #29

### Description
Adds a federated query to WDQS to be able to still use the `wikibase:mwapi` service and perform full-text searches.

### Caveats
Does re-introduce a dependency on WDQS.

### Checklist
* [x] I have [commented](https://peps.python.org/pep-0008/#comments) my code, particularly in hard-to-understand areas
* [x] My changes generate no new warnings
* [x] I have not used code from external sources without attribution
* [x] I have considered [accessibility](https://www.w3.org/standards/webdesign/accessibility) in my implementation 
* [x] There are no remaining debug statements (print, console.log, ...)
