### PR TITLE
Implements handling Wikidata items without label

### DIFF
--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -155,7 +155,7 @@ function convertDataTableData(data, columns) {
 		    $("<div>").text(data[i][key]).html() + '</a>';
 
 	    } else {
-		    convertedRowValue = data[i][key];
+		    var convertedRowValue = data[i][key];
 		    if (convertedRowValue.startsWith("http://www.wikidata.org/entity/Q")) {
 		        qid = convertedRowValue.slice(31);
 		        convertedRowValue = '<a href="../' + qid + '">' + qid + '</a>';

--- a/scholia/app/static/scholia.js
+++ b/scholia/app/static/scholia.js
@@ -155,7 +155,12 @@ function convertDataTableData(data, columns) {
 		    $("<div>").text(data[i][key]).html() + '</a>';
 
 	    } else {
-		    convertedRow[key] = data[i][key];
+		    convertedRowValue = data[i][key];
+		    if (convertedRowValue.startsWith("http://www.wikidata.org/entity/Q")) {
+		        qid = convertedRowValue.slice(31);
+		        convertedRowValue = '<a href="../' + qid + '">' + qid + '</a>';
+		    }
+		    convertedRow[key] = convertedRowValue;
 	    }
 	}
 	convertedData.push(convertedRow);


### PR DESCRIPTION
The new `wikibase:label` alternative (the macros) do not default to showing a linked QID as the wikibase solution does. So, when you ask for `en_US, en, mul` (when `en_US` is the browser AUTO_LANGUAGE) and the item only has a `de` label, then you so far get something like this:

<img width="1121" height="657" alt="image" src="https://github.com/user-attachments/assets/5b878a52-ad7c-478d-864c-28b99600f52a" />

This was discussed in [this post and follow up replies](https://github.com/ad-freiburg/scholia/issues/39#issuecomment-3651600433)

I implemented the suggested JavaScript-level solution, to not have to further extend the SPARQL query. The code detects Wikidata items IRIs, and at the same time, I have it link to Scholia (instead of Wikidata):

<img width="1121" height="657" alt="image" src="https://github.com/user-attachments/assets/6311c5f2-d009-44c6-84fe-16b6dec6ec0e" />

@pfps, @larsgw, @hannahbast, please let me know what you think of this approach.