### PR TITLE
fix label service for complex; improve performance

### DIFF
--- a/scholia/app/templates/complex_articles-by-year.sparql
+++ b/scholia/app/templates/complex_articles-by-year.sparql
@@ -10,8 +10,7 @@ SELECT (STR(?year_) AS ?year) (COUNT(?work) AS ?number_of_publications)
   {
     { # Find works with the topic. Also report the year
       SELECT ?work (MIN(?years) AS ?year_) (1 AS ?dummy) (SAMPLE(?article_type_) AS ?article_type) WHERE {
-        VALUES ?complex { target: }
-        ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) ?complex .
+        ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
         ?work wdt:P577 ?dates .
         BIND (YEAR(?dates) AS ?years) .
         ?work wdt:P31 ?article_type_ .
@@ -35,8 +34,7 @@ SELECT (STR(?year_) AS ?year) (COUNT(?work) AS ?number_of_publications)
     SELECT (MIN(?year_) AS ?earliest_year) WHERE {
       { # Find works with the topic. Also report the year
         SELECT ?work (MIN(?years) AS ?year_) (1 AS ?dummy) (SAMPLE(?article_type_) AS ?article_type) WHERE {
-          VALUES ?complex { target: }
-          ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) ?complex .
+          ?work wdt:P921/(wdt:P31*/wdt:P279* | wdt:P361+ | wdt:P1269+) target: .
           ?work wdt:P577 ?dates .
           BIND (YEAR(?dates) AS ?years) .
           ?work wdt:P31 ?article_type_ .

--- a/scholia/app/templates/complex_articles-recent.sparql
+++ b/scholia/app/templates/complex_articles-recent.sparql
@@ -1,16 +1,16 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
 PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
-SELECT ?date ?work (REPLACE(STR(?work), ".*/", "") AS ?workLabel) ?topicsUrl ?topics WHERE {
+SELECT ?date ?work ?workLabel ?topicsUrl ?topics WHERE {
   {
     SELECT (MAX(?dates) AS ?datetime) ?work (GROUP_CONCAT(DISTINCT ?topic_label; SEPARATOR=" // ") AS ?topics) (CONCAT("../topics/", GROUP_CONCAT(DISTINCT SUBSTR(STR(?topic),32); SEPARATOR=",")) AS ?topicsUrl) WHERE {
       {
         SELECT DISTINCT ?work WHERE {
-          VALUES ?complex { target: }
-          ?work wdt:P921/(wdt:P361+ | wdt:P1269+ | (wdt:P31*/wdt:P279*)) ?complex .
+          ?work wdt:P921/(wdt:P361+ | wdt:P1269+ | (wdt:P31*/wdt:P279*)) target: .
         }
       }
       ?work wdt:P921 ?topic .
@@ -24,7 +24,7 @@ SELECT ?date ?work (REPLACE(STR(?work), ".*/", "") AS ?workLabel) ?topicsUrl ?to
   # There is a problem with BC dates
   # BIND(xsd:date(?datetime) AS ?date)
   BIND (REPLACE(STR(?datetime), 'T.*', '') AS ?date)
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+  {{ sparql_helpers.labels(["?work"], languages) }}
 }
 GROUP BY ?date ?work ?workLabel ?topicsUrl ?topics
 ORDER BY DESC(?date)

--- a/scholia/app/templates/complex_identifiers.sparql
+++ b/scholia/app/templates/complex_identifiers.sparql
@@ -1,3 +1,4 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
 # tool: scholia
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
@@ -9,8 +10,7 @@ SELECT ?Identifier ?IdentifierLabel ?id (SAMPLE(?idUrls) AS ?idUrl) ?IdentifierD
     SELECT * WHERE {
       {
         SELECT ?Identifier ?id ?formatterurl WHERE {
-          VALUES ?complex { target: }
-          ?complex ?IDdir ?id .
+          target: ?IDdir ?id .
           ?Identifier wikibase:directClaim ?IDdir ;
                       wdt:P31/wdt:P279* wd:Q19847637 .
           OPTIONAL {
@@ -30,8 +30,7 @@ SELECT ?Identifier ?IdentifierLabel ?id (SAMPLE(?idUrls) AS ?idUrl) ?IdentifierD
     SELECT * WHERE {
       {
         SELECT ?Identifier ?id ?formatterurl WHERE {
-          VALUES ?complex { target: }
-          ?complex ?IDdir ?id .
+          target: ?IDdir ?id .
           ?Identifier wikibase:directClaim ?IDdir ;
                       wdt:P31/wdt:P279* wd:Q19847637 .
           OPTIONAL {
@@ -47,7 +46,8 @@ SELECT ?Identifier ?IdentifierLabel ?id (SAMPLE(?idUrls) AS ?idUrl) ?IdentifierD
       BIND (IRI(REPLACE(?formatterurl, '\\\\$1', STR(?id))) AS ?idUrls) .
     }
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en". }
+  {{ sparql_helpers.labels(["?Identifier"], languages) }}
+  {{ sparql_helpers.descriptions(["?Identifier"], languages) }}
 }
 GROUP BY ?Identifier ?IdentifierLabel ?IdentifierDescription ?id
 ORDER BY ASC(?IdentifierLabel)

--- a/scholia/app/templates/complex_participants.sparql
+++ b/scholia/app/templates/complex_participants.sparql
@@ -1,3 +1,4 @@
+{% import 'sparql-helpers.sparql' as sparql_helpers -%}
 PREFIX target: <http://www.wikidata.org/entity/{{ q }}>
 PREFIX bd: <http://www.bigdata.com/rdf#>
 PREFIX p: <http://www.wikidata.org/prop/>
@@ -6,11 +7,10 @@ PREFIX ps: <http://www.wikidata.org/prop/statement/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 PREFIX wikibase: <http://wikiba.se/ontology#>
-SELECT ?quantity ?part (REPLACE(STR(?part), ".*/", "") AS ?partLabel) ?partDescription ?type WHERE {
+SELECT ?quantity ?part ?partLabel ?partDescription ?type WHERE {
   {
     SELECT ?part ?quantity (GROUP_CONCAT(DISTINCT ?type_label; SEPARATOR=", ") AS ?type) WHERE {
-      VALUES ?complex { target: }
-      ?complex p:P527 ?partStatement .
+      target: p:P527 ?partStatement .
       ?partStatement ps:P527 ?part .
       OPTIONAL {
         ?partStatement pq:P1114 ?quantity
@@ -23,6 +23,7 @@ SELECT ?quantity ?part (REPLACE(STR(?part), ".*/", "") AS ?partLabel) ?partDescr
     }
     GROUP BY ?part ?quantity
   }
-  # SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],mul,en" . }
+  {{ sparql_helpers.labels(["?part"], languages) }}
+  {{ sparql_helpers.descriptions(["?part"], languages) }}
 }
 ORDER BY ASC(?partLabel)


### PR DESCRIPTION
Fixes # (issue number, if applicable) 

### Description
as stated

sometimes the queries run out of space, but that might just be due to memory starvation on the QLever server
