### PR TITLE
fix chemical queries

### DIFF
--- a/scholia/app/templates/chemical_found-in-taxon.sparql
+++ b/scholia/app/templates/chemical_found-in-taxon.sparql
@@ -7,13 +7,22 @@ PREFIX ps: <http://www.wikidata.org/prop/statement/>
 PREFIX wd: <http://www.wikidata.org/entity/>
 PREFIX wdt: <http://www.wikidata.org/prop/direct/>
 SELECT DISTINCT ?taxon ?taxonLabel (CONCAT("/taxon/", SUBSTR(STR(?taxon),32)) AS ?taxonUrl) ?source ?sourceLabel (CONCAT("/work/", SUBSTR(STR(?source),32)) AS ?sourceUrl) ?doi WHERE {
-  wd:{{ q }} p:P703 ?taxonStatement .
-  ?taxonStatement ps:P703 wd:{{ q }} .
-  OPTIONAL {
-    ?taxonStatement prov:wasDerivedFrom/pr:P248 ?source .
-    OPTIONAL {
-      ?source wdt:P356 ?doi .
-    }
+  {
+    SELECT DISTINCT ?taxon (SAMPLE (?source_) AS ?source) (SAMPLE (?doi_) AS ?doi) WHERE {
+      {
+        wd:{{ q }} p:P703 ?taxonStatement .
+        ?taxonStatement ps:P703 ?taxon .
+      } UNION {
+        wd:{{ q }} p:P703 ?taxonStatement .
+        ?taxonStatement ps:P703 ?taxon .
+        ?taxonStatement prov:wasDerivedFrom/pr:P248 ?source_ .
+      } UNION {
+        wd:{{ q }} p:P703 ?taxonStatement .
+        ?taxonStatement ps:P703 ?taxon .
+        ?taxonStatement prov:wasDerivedFrom/pr:P248 ?source_ .
+        ?source_ wdt:P356 ?doi_ .
+      } 
+    } GROUP BY ?taxon
   }
   {{ sparql_helpers.labels(["?taxon"], languages) }}
   {{ sparql_helpers.labels_unbound(["?source"], languages) }}

--- a/scholia/app/templates/chemical_physchem-properties.sparql
+++ b/scholia/app/templates/chemical_physchem-properties.sparql
@@ -12,38 +12,44 @@ PREFIX wikibase: <http://wikiba.se/ontology#>
 SELECT DISTINCT ?propEntity ?propEntityLabel ?value ?units ?unitsLabel ?qualifiers ?source ?sourceLabel ?doi WHERE {
   {
     SELECT DISTINCT ?propEntity ?value ?units ?source ?doi (GROUP_CONCAT(?qualifierStr; SEPARATOR=", ") AS ?qualifiers) WHERE {
-      target: ?propp ?statement .
-      ?statement a wikibase:BestRank ;
-                 ?proppsv [
-        wikibase:quantityAmount ?value ; wikibase:quantityUnit ?units
-      ] .
-      OPTIONAL {
-        ?statement prov:wasDerivedFrom/pr:P248 ?source .
-        OPTIONAL {
-          ?source wdt:P356 ?doi .
-        }
-      }
-      ?property wikibase:claim ?propp ;
+      {
+        SELECT DISTINCT ?propEntity ?value ?units (SAMPLE (?source_) AS ?source) (SAMPLE( ?doi_) AS ?doi) WHERE {
+          { 
+            target: ?propp ?statement .
+            ?statement a wikibase:BestRank ; ?proppsv [ wikibase:quantityAmount ?value ; wikibase:quantityUnit ?units ] .
+          } UNION {
+            target: ?propp ?statement .
+            ?statement a wikibase:BestRank ; ?proppsv [ wikibase:quantityAmount ?value ; wikibase:quantityUnit ?units ] .
+            ?statement prov:wasDerivedFrom/pr:P248 ?source_ .
+          } UNION {
+            target: ?propp ?statement .
+            ?statement a wikibase:BestRank ; ?proppsv [ wikibase:quantityAmount ?value ; wikibase:quantityUnit ?units ] .
+            ?statement prov:wasDerivedFrom/pr:P248 ?source_ .
+            ?source_ wdt:P356 ?doi_ .
+          } 
+          ?property wikibase:claim ?propp ;
                 wikibase:statementValue ?proppsv ;
                 wdt:P1629 ?propEntity ;
                 wdt:P31 wd:Q21077852 .
-      OPTIONAL {
-        {
-          ?qualifierProp wikibase:qualifier ?qualifier ;
-                         rdfs:label ?qProplabel ; FILTER (LANG(?qProplabel) = "en") .
-          ?qualifier a owl:DatatypeProperty .
-          ?statement ?qualifier ?qualifierVal .
-          BIND (CONCAT(STR(?qProplabel), ": ", STR(?qualifierVal)) AS ?qualifierStr)
-        }
-        UNION {
-          ?qualifierProp wikibase:qualifier ?qualifier ;
-                         rdfs:label ?qProplabel ; FILTER (LANG(?qProplabel) = "en") .
-          ?qualifier a owl:ObjectProperty .
-          ?statement ?qualifier ?qualifierVal .
-          ?qualifierVal rdfs:label ?qVallabel ; FILTER (LANG(?qVallabel) = "en") .
-          BIND (CONCAT(STR(?qProplabel), ": ", STR(?qVallabel)) AS ?qualifierStr)
-        }
+        } GROUP BY ?propEntity ?value ?units 
       }
+##      OPTIONAL {
+##        {
+##          ?qualifierProp wikibase:qualifier ?qualifier ;
+##                         rdfs:label ?qProplabel ; FILTER (LANG(?qProplabel) = "en") .
+##          ?qualifier a owl:DatatypeProperty .
+##          ?statement ?qualifier ?qualifierVal .
+##          BIND (CONCAT(STR(?qProplabel), ": ", STR(?qualifierVal)) AS ?qualifierStr)
+##        }
+##        UNION {
+##          ?qualifierProp wikibase:qualifier ?qualifier ;
+##                         rdfs:label ?qProplabel ; FILTER (LANG(?qProplabel) = "en") .
+##          ?qualifier a owl:ObjectProperty .
+##          ?statement ?qualifier ?qualifierVal .
+##          ?qualifierVal rdfs:label ?qVallabel ; FILTER (LANG(?qVallabel) = "en") .
+##          BIND (CONCAT(STR(?qProplabel), ": ", STR(?qVallabel)) AS ?qualifierStr)
+##        }
+##      }
     }
     GROUP BY ?propEntity ?value ?units ?source ?doi
   }

--- a/scholia/app/templates/chemical_physchem-properties.sparql
+++ b/scholia/app/templates/chemical_physchem-properties.sparql
@@ -13,7 +13,7 @@ SELECT DISTINCT ?propEntity ?propEntityLabel ?value ?units ?unitsLabel ?qualifie
   {
     SELECT DISTINCT ?propEntity ?value ?units ?source ?doi (GROUP_CONCAT(?qualifierStr; SEPARATOR=", ") AS ?qualifiers) WHERE {
       {
-        SELECT DISTINCT ?propEntity ?value ?units (SAMPLE (?source_) AS ?source) (SAMPLE( ?doi_) AS ?doi) WHERE {
+        SELECT DISTINCT ?propEntity ?statement ?value ?units (SAMPLE (?source_) AS ?source) (SAMPLE( ?doi_) AS ?doi) WHERE {
           { 
             target: ?propp ?statement .
             ?statement a wikibase:BestRank ; ?proppsv [ wikibase:quantityAmount ?value ; wikibase:quantityUnit ?units ] .
@@ -26,30 +26,33 @@ SELECT DISTINCT ?propEntity ?propEntityLabel ?value ?units ?unitsLabel ?qualifie
             ?statement a wikibase:BestRank ; ?proppsv [ wikibase:quantityAmount ?value ; wikibase:quantityUnit ?units ] .
             ?statement prov:wasDerivedFrom/pr:P248 ?source_ .
             ?source_ wdt:P356 ?doi_ .
-          } 
+          }
           ?property wikibase:claim ?propp ;
                 wikibase:statementValue ?proppsv ;
                 wdt:P1629 ?propEntity ;
                 wdt:P31 wd:Q21077852 .
-        } GROUP BY ?propEntity ?value ?units 
-      }
-##      OPTIONAL {
-##        {
-##          ?qualifierProp wikibase:qualifier ?qualifier ;
-##                         rdfs:label ?qProplabel ; FILTER (LANG(?qProplabel) = "en") .
-##          ?qualifier a owl:DatatypeProperty .
-##          ?statement ?qualifier ?qualifierVal .
-##          BIND (CONCAT(STR(?qProplabel), ": ", STR(?qualifierVal)) AS ?qualifierStr)
-##        }
-##        UNION {
-##          ?qualifierProp wikibase:qualifier ?qualifier ;
-##                         rdfs:label ?qProplabel ; FILTER (LANG(?qProplabel) = "en") .
-##          ?qualifier a owl:ObjectProperty .
-##          ?statement ?qualifier ?qualifierVal .
-##          ?qualifierVal rdfs:label ?qVallabel ; FILTER (LANG(?qVallabel) = "en") .
-##          BIND (CONCAT(STR(?qProplabel), ": ", STR(?qVallabel)) AS ?qualifierStr)
-##        }
-##      }
+        } GROUP BY ?propEntity ?value ?units ?statement
+      } 
+      OPTIONAL {      
+          ?property wikibase:claim ?propp ;
+                    wdt:P1629 ?propEntity .
+          { 
+            target: ?propp ?statement .
+            ?statement ?qualifier ?qualifierVal .
+            ?qualifier a owl:DatatypeProperty .
+            ?qualifierProp wikibase:qualifier ?qualifier ;
+                         rdfs:label ?qProplabel ; FILTER (LANG(?qProplabel) = "en") .
+            BIND (CONCAT(STR(?qProplabel), ": ", STR(?qualifierVal)) AS ?qualifierStr)
+          } UNION {
+            target: ?propp ?statement .
+            ?statement ?qualifier ?qualifierVal .
+            ?qualifier a owl:ObjectProperty .
+            ?qualifierVal rdfs:label ?qVallabel ; FILTER (LANG(?qVallabel) = "en") .
+            ?qualifierProp wikibase:qualifier ?qualifier ;
+                         rdfs:label ?qProplabel ; FILTER (LANG(?qProplabel) = "en") .
+            BIND (CONCAT(STR(?qProplabel), ": ", STR(?qVallabel)) AS ?qualifierStr)
+          }
+       }
     }
     GROUP BY ?propEntity ?value ?units ?source ?doi
   }


### PR DESCRIPTION
Fixes # (issue number, if applicable) 

### Description
patch expensive OPTIONALs in chemical_found-in-taxon.sparql and chemical_physchem-properties.sparql
comment out expensive OPTIONAL in chemical_physchem-properties.sparql
fix bug in chemical_found-in-taxon.sparql 